### PR TITLE
merge: testing refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ kustomize
 .venv
 .vscode
 .DS_Store
+.idea

--- a/go-daemon/api/cni.go
+++ b/go-daemon/api/cni.go
@@ -15,8 +15,8 @@ import (
 
 type CNIController struct {
 	repo       db.Registry
-	vnfFactory *vnfs.InstanceFactory
-	appFactory *apps.InstanceFactory
+	vnfFactory vnfs.InstanceFactory
+	appFactory apps.InstanceFactory
 }
 
 var validate *validator.Validate
@@ -200,7 +200,7 @@ func (c *CNIController) handleVnfInstanceTeardown(response http.ResponseWriter, 
 //
 // This API will be used by the CNI plugin to register and unregister
 // application and VNF containers.
-func InitializeCNIApi(appFactory *apps.InstanceFactory, vnfFactory *vnfs.InstanceFactory, repo db.Registry) (*http.Server, error) {
+func InitializeCNIApi(appFactory apps.InstanceFactory, vnfFactory vnfs.InstanceFactory, repo db.Registry) (*http.Server, error) {
 	// Validate the services
 	if appFactory == nil || vnfFactory == nil || repo == nil {
 		return nil, fmt.Errorf("appFactory, vnfFactory, and repo cannot be nil")

--- a/go-daemon/api/cni.go
+++ b/go-daemon/api/cni.go
@@ -3,9 +3,9 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"iml-daemon/apps"
 	"iml-daemon/db"
 	"iml-daemon/logger"
-	"iml-daemon/apps"
 	"iml-daemon/vnfs"
 	"net/http"
 
@@ -14,7 +14,7 @@ import (
 )
 
 type CNIController struct {
-	repo       *db.Registry
+	repo       db.Registry
 	vnfFactory *vnfs.InstanceFactory
 	appFactory *apps.InstanceFactory
 }
@@ -61,11 +61,11 @@ func (c *CNIController) handleAppInstanceRegistration(response http.ResponseWrit
 	}
 
 	configResponse := &AppInstanceConfigResponse{
-		IPNet:        regResponse.IPNet.String(),
-		IfaceName:    regResponse.IfaceName,
-		ClusterCIDR:  regResponse.ClusterCIDR.String(),
-		GatewayIP:    regResponse.GatewayIP.String(),
-		BridgeName:   regResponse.BridgeName,
+		IPNet:       regResponse.IPNet.String(),
+		IfaceName:   regResponse.IfaceName,
+		ClusterCIDR: regResponse.ClusterCIDR.String(),
+		GatewayIP:   regResponse.GatewayIP.String(),
+		BridgeName:  regResponse.BridgeName,
 	}
 
 	// Finally, return the container details including the allocated IP.
@@ -200,7 +200,7 @@ func (c *CNIController) handleVnfInstanceTeardown(response http.ResponseWriter, 
 //
 // This API will be used by the CNI plugin to register and unregister
 // application and VNF containers.
-func InitializeCNIApi(appFactory *apps.InstanceFactory, vnfFactory *vnfs.InstanceFactory, repo *db.Registry) (*http.Server, error) {
+func InitializeCNIApi(appFactory *apps.InstanceFactory, vnfFactory *vnfs.InstanceFactory, repo db.Registry) (*http.Server, error) {
 	// Validate the services
 	if appFactory == nil || vnfFactory == nil || repo == nil {
 		return nil, fmt.Errorf("appFactory, vnfFactory, and repo cannot be nil")

--- a/go-daemon/apps/apps_test.go
+++ b/go-daemon/apps/apps_test.go
@@ -1,4 +1,4 @@
-package vnfs
+package apps
 
 import (
 	"iml-daemon/internal/testutil"
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestVNFInstanceFactoryCreationFailsWhenDependenciesAreNil(t *testing.T) {
+func TestAppInstanceFactoryCreationFailsWhenDependenciesAreNil(t *testing.T) {
 	t.Run("Error should be thrown when repo is nil", func(t *testing.T) {
 		t.Parallel()
 		bus := new(testutil.MockEventBus)
@@ -48,50 +48,4 @@ func TestVNFInstanceFactoryCreationFailsWhenDependenciesAreNil(t *testing.T) {
 		assert.Nil(t, factory)
 		assert.Error(t, err)
 	})
-}
-
-func TestInstanceRegistration(t *testing.T) {
-	// Defining the columns of the table
-	var tests = []struct {
-		name string
-			input *RegistrationRequest
-			want  *InstanceRegistrationResponse
-	}{
-		// the table itself
-		{"9 should be Foo",
-			&RegistrationRequest{}, 
-			&InstanceRegistrationResponse{}},
-		{"3 should be Foo",
-			&RegistrationRequest{}, 
-			&InstanceRegistrationResponse{}},
-		{"1 is not Foo",
-			&RegistrationRequest{}, 
-			&InstanceRegistrationResponse{}},
-		{"0 should be Foo",
-			&RegistrationRequest{}, 
-			&InstanceRegistrationResponse{}},
-	}
-
-	// Create the mock dependencies
-	repo := new(testutil.MockRepo)
-	bus := new(testutil.MockEventBus)
-	dataplane := new(testutil.MockDataplaneManager)
-	imlClient := new(testutil.MockIMLClient)
-
-	// Set up mock expectations
-	// repo.On("SaveInstance", mock.Anything).Return(nil)
-
-	// Set up the factory
-	factory, err := NewInstanceFactory(repo, bus, dataplane, imlClient)
-	assert.NoError(t, err)
-
-	// The execution loop
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel() // Run test in parallel
-			response, err := factory.NewLocalInstance(tt.input)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.want, response)
-		})
-	}
 }

--- a/go-daemon/apps/factory.go
+++ b/go-daemon/apps/factory.go
@@ -8,15 +8,15 @@ import (
 	"iml-daemon/models"
 	"iml-daemon/services/events"
 	"iml-daemon/services/iml"
-	"iml-daemon/services/router"
+	"iml-daemon/services/router/dataplane"
 	"net"
 )
 
 type InstanceFactory struct {
-	repo      *db.Registry
-	bus       *events.EventBus
-	imlClient *iml.Client
-	dataplane *router.Dataplane
+	repo      db.Registry
+	bus       events.EventBus
+	imlClient iml.Client
+	dataplane dataplane.Manager
 }
 
 type RegistrationRequest struct {
@@ -33,10 +33,10 @@ type InstanceRegistrationResponse struct {
 }
 
 func NewInstanceFactory(
-	repo *db.Registry, 
-	bus *events.EventBus, 
-	dataplane *router.Dataplane,
-	imlClient *iml.Client) (*InstanceFactory, error) {
+	repo db.Registry,
+	bus events.EventBus,
+	dataplane dataplane.Manager,
+	imlClient iml.Client) (*InstanceFactory, error) {
 	if bus == nil {
 		return nil, fmt.Errorf("event bus is required")
 	}
@@ -94,9 +94,9 @@ func (f *InstanceFactory) createOrGetAppInstance(req *RegistrationRequest, app *
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to request application subnet: %v", err)
 		}
-		appGroup.Subnet = subnet.Network.String()
-		appGroup.GatewayIP = subnet.GatewayIP.String()
-		appGroup.Bridge = subnet.Bridge.Attrs().Name
+		appGroup.Subnet = subnet.Network().String()
+		appGroup.GatewayIP = subnet.GatewayIP().String()
+		appGroup.Bridge = subnet.Bridge()
 		if err := f.repo.SaveAppGroup(appGroup); err != nil {
 			return nil, nil, fmt.Errorf("failed to update app group with subnet info: %v", err)
 		}

--- a/go-daemon/apps/factory.go
+++ b/go-daemon/apps/factory.go
@@ -9,34 +9,20 @@ import (
 	"iml-daemon/services/events"
 	"iml-daemon/services/iml"
 	"iml-daemon/services/router/dataplane"
-	"net"
 )
 
-type InstanceFactory struct {
+type InstanceFactoryImpl struct {
 	repo      db.Registry
 	bus       events.EventBus
 	imlClient iml.Client
 	dataplane dataplane.Manager
 }
 
-type RegistrationRequest struct {
-	ApplicationID string
-	ContainerID   string
-}
-
-type InstanceRegistrationResponse struct {
-	IPNet       net.IPNet
-	IfaceName   string
-	ClusterCIDR net.IPNet
-	GatewayIP   net.IP
-	BridgeName  string
-}
-
 func NewInstanceFactory(
 	repo db.Registry,
 	bus events.EventBus,
 	dataplane dataplane.Manager,
-	imlClient iml.Client) (*InstanceFactory, error) {
+	imlClient iml.Client) (InstanceFactory, error) {
 	if repo == nil {
 		return nil, fmt.Errorf("repository is required")
 	}
@@ -50,7 +36,7 @@ func NewInstanceFactory(
 		return nil, fmt.Errorf("IML client is required")
 	}
 
-	return &InstanceFactory{
+	return &InstanceFactoryImpl{
 		repo:      repo,
 		bus:       bus,
 		imlClient: imlClient,
@@ -58,7 +44,7 @@ func NewInstanceFactory(
 	}, nil
 }
 
-func (f *InstanceFactory) NewLocalInstance(req *RegistrationRequest) (*InstanceRegistrationResponse, error) {
+func (f *InstanceFactoryImpl) NewLocalInstance(req *RegistrationRequest) (*InstanceRegistrationResponse, error) {
 	app, err := f.imlClient.GetApplication(req.ApplicationID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get application %s: %v", req.ApplicationID, err)
@@ -84,7 +70,7 @@ func (f *InstanceFactory) NewLocalInstance(req *RegistrationRequest) (*InstanceR
 	return response, nil
 }
 
-func (f *InstanceFactory) createOrGetAppInstance(req *RegistrationRequest, app *models.Application) (*models.AppInstance, *models.AppGroup, error) {
+func (f *InstanceFactoryImpl) createOrGetAppInstance(req *RegistrationRequest, app *models.Application) (*models.AppInstance, *models.AppGroup, error) {
 	appGroup, _ := f.repo.FindLocalAppGroupByGlobalID(app.GlobalID)
 	if appGroup == nil {
 		// Create a new app group if it doesn't exist
@@ -141,7 +127,7 @@ func (f *InstanceFactory) createOrGetAppInstance(req *RegistrationRequest, app *
 	return instance, appGroup, nil
 }
 
-func (f *InstanceFactory) DeleteInstance(containerID string) error {
+func (f *InstanceFactoryImpl) DeleteInstance(containerID string) error {
 	// First, find the application instance by container ID
 	// If it does not exist, just return
 	instance, _ := f.repo.FindAppInstanceByContainerID(containerID)

--- a/go-daemon/apps/factory.go
+++ b/go-daemon/apps/factory.go
@@ -37,11 +37,17 @@ func NewInstanceFactory(
 	bus events.EventBus,
 	dataplane dataplane.Manager,
 	imlClient iml.Client) (*InstanceFactory, error) {
+	if repo == nil {
+		return nil, fmt.Errorf("repository is required")
+	}
 	if bus == nil {
 		return nil, fmt.Errorf("event bus is required")
 	}
-	if repo == nil {
-		return nil, fmt.Errorf("repository is required")
+	if dataplane == nil {
+		return nil, fmt.Errorf("dataplane manager is required")
+	}
+	if imlClient == nil {
+		return nil, fmt.Errorf("IML client is required")
 	}
 
 	return &InstanceFactory{

--- a/go-daemon/apps/types.go
+++ b/go-daemon/apps/types.go
@@ -1,0 +1,21 @@
+package apps
+
+import "net"
+
+type InstanceFactory interface {
+	NewLocalInstance(req *RegistrationRequest) (*InstanceRegistrationResponse, error)
+	DeleteInstance(containerID string) error
+}
+
+type RegistrationRequest struct {
+	ApplicationID string
+	ContainerID   string
+}
+
+type InstanceRegistrationResponse struct {
+	IPNet       net.IPNet
+	IfaceName   string
+	ClusterCIDR net.IPNet
+	GatewayIP   net.IP
+	BridgeName  string
+}

--- a/go-daemon/db/clients.go
+++ b/go-daemon/db/clients.go
@@ -8,7 +8,14 @@ import (
 	"gorm.io/gorm"
 )
 
-func InitializeInMemoryRegistry() (*Registry, error) {
+// InMemoryRegistry is the main entrypoint to accessing the database.
+// It provides methods to find applications, app instances, VNFs, and VNF instances.
+// It uses GORM for database operations.
+type InMemoryRegistry struct {
+	dbHandle *gorm.DB
+}
+
+func InitializeInMemoryRegistry() (Registry, error) {
 	db, err := gorm.Open(sqlite.Open("test.db"), &gorm.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to the database: %w", err)
@@ -49,7 +56,7 @@ func InitializeInMemoryRegistry() (*Registry, error) {
 	// 	return nil, fmt.Errorf("failed to setup join table for Route and RouteStage: %w", err)
 	// }
 
-	return &Registry{
+	return &InMemoryRegistry{
 		dbHandle: db,
 	}, nil
 }

--- a/go-daemon/db/db_test.go
+++ b/go-daemon/db/db_test.go
@@ -1,0 +1,8 @@
+package db
+
+import (
+	"testing"
+)
+
+func TestXxx(t *testing.T) {
+}

--- a/go-daemon/db/queries.go
+++ b/go-daemon/db/queries.go
@@ -8,15 +8,7 @@ import (
 	"github.com/google/uuid"
 )
 
-func (r *Registry) FindAppById(id uuid.UUID) (*models.Application, error) {
-	var app models.Application
-	if err := r.dbHandle.First(&app, "id = ?", id).Error; err != nil {
-		return nil, fmt.Errorf("application with id %s not found: %w", id, err)
-	}
-	return &app, nil
-}
-
-func (r *Registry) FindActiveAppByLocalID(localID uuid.UUID) (*models.Application, error) {
+func (r *InMemoryRegistry) FindActiveAppByLocalID(localID uuid.UUID) (*models.Application, error) {
 	var app models.Application
 	if err := r.dbHandle.First(&app, "id = ? AND status = ?", localID, models.AppStatusActive).Error; err != nil {
 		return nil, fmt.Errorf("application with local ID %s not found: %w", localID, err)
@@ -24,7 +16,7 @@ func (r *Registry) FindActiveAppByLocalID(localID uuid.UUID) (*models.Applicatio
 	return &app, nil
 }
 
-func (r *Registry) FindActiveAppByGlobalID(globalID string) (*models.Application, error) {
+func (r *InMemoryRegistry) FindActiveAppByGlobalID(globalID string) (*models.Application, error) {
 	var app models.Application
 	if err := r.dbHandle.First(&app, "global_id = ? AND status = ?", globalID, models.AppStatusActive).Error; err != nil {
 		return nil, fmt.Errorf("application with global ID %s not found: %w", globalID, err)
@@ -32,15 +24,7 @@ func (r *Registry) FindActiveAppByGlobalID(globalID string) (*models.Application
 	return &app, nil
 }
 
-func (r *Registry) FindAllApps() ([]*models.Application, error) {
-	var apps []*models.Application
-	if err := r.dbHandle.Find(&apps).Error; err != nil {
-		return nil, fmt.Errorf("failed to find all applications: %w", err)
-	}
-	return apps, nil
-}
-
-func (r *Registry) FindLocalAppGroupByGlobalID(globalAppID string) (*models.AppGroup, error) {
+func (r *InMemoryRegistry) FindLocalAppGroupByGlobalID(globalAppID string) (*models.AppGroup, error) {
 	// As the app group model does not have global_id directly, we obtain it by joining with the applications table.
 	var group models.AppGroup
 	if err := r.dbHandle.Joins("JOIN applications ON applications.id = app_groups.app_id").Where("applications.global_id = ?", globalAppID).First(&group).Error; err != nil {
@@ -49,7 +33,7 @@ func (r *Registry) FindLocalAppGroupByGlobalID(globalAppID string) (*models.AppG
 	return &group, nil
 }
 
-func (r *Registry) FindAppGroupByID(id uuid.UUID) (*models.AppGroup, error) {
+func (r *InMemoryRegistry) FindAppGroupByID(id uuid.UUID) (*models.AppGroup, error) {
 	var group models.AppGroup
 	if err := r.dbHandle.First(&group, "id = ?", id).Error; err != nil {
 		return nil, fmt.Errorf("app group with id %s not found: %w", id, err)
@@ -57,7 +41,7 @@ func (r *Registry) FindAppGroupByID(id uuid.UUID) (*models.AppGroup, error) {
 	return &group, nil
 }
 
-func (r *Registry) FindAppInstanceByContainerID(containerID string) (*models.AppInstance, error) {
+func (r *InMemoryRegistry) FindAppInstanceByContainerID(containerID string) (*models.AppInstance, error) {
 	var instance models.AppInstance
 	if err := r.dbHandle.First(&instance, "container_id = ?", containerID).Error; err != nil {
 		return nil, fmt.Errorf("app instance with container ID %s not found: %w", containerID, err)
@@ -65,39 +49,7 @@ func (r *Registry) FindAppInstanceByContainerID(containerID string) (*models.App
 	return &instance, nil
 }
 
-func (r *Registry) FindAppInstancesByAppID(appID string) ([]*models.AppInstance, error) {
-	var instances []*models.AppInstance
-	if err := r.dbHandle.Find(&instances, "app_id = ?", appID).Error; err != nil {
-		return nil, fmt.Errorf("failed to find app instances for app ID %s: %w", appID, err)
-	}
-	return instances, nil
-}
-
-func (r *Registry) FindAppInstancesByGroupID(groupID uuid.UUID) ([]*models.AppInstance, error) {
-	var instances []*models.AppInstance
-	if err := r.dbHandle.Find(&instances, "group_id = ?", groupID).Error; err != nil {
-		return nil, fmt.Errorf("failed to find app instances for group ID %s: %w", groupID, err)
-	}
-	return instances, nil
-}
-
-func (r *Registry) FindAllNetworkFunctions() ([]*models.VirtualNetworkFunction, error) {
-	var functions []*models.VirtualNetworkFunction
-	if err := r.dbHandle.Find(&functions).Error; err != nil {
-		return nil, fmt.Errorf("failed to find all network functions: %w", err)
-	}
-	return functions, nil
-}
-
-func (r *Registry) FindNetworkFunctionByID(id uuid.UUID) (*models.VirtualNetworkFunction, error) {
-	var function models.VirtualNetworkFunction
-	if err := r.dbHandle.First(&function, "id = ?", id).Error; err != nil {
-		return nil, fmt.Errorf("network function with id %s not found: %w", id, err)
-	}
-	return &function, nil
-}
-
-func (r *Registry) FindActiveNetworkFunctionByLocalID(localID uuid.UUID) (*models.VirtualNetworkFunction, error) {
+func (r *InMemoryRegistry) FindActiveNetworkFunctionByLocalID(localID uuid.UUID) (*models.VirtualNetworkFunction, error) {
 	var vnf models.VirtualNetworkFunction
 	if err := r.dbHandle.First(&vnf, "id = ? AND status = ?", localID, models.VNFStatusActive).Error; err != nil {
 		return nil, fmt.Errorf("VNF with local ID %s not found: %w", localID, err)
@@ -105,7 +57,7 @@ func (r *Registry) FindActiveNetworkFunctionByLocalID(localID uuid.UUID) (*model
 	return &vnf, nil
 }
 
-func (r *Registry) FindActiveNetworkFunctionByGlobalID(globalID string) (*models.VirtualNetworkFunction, error) {
+func (r *InMemoryRegistry) FindActiveNetworkFunctionByGlobalID(globalID string) (*models.VirtualNetworkFunction, error) {
 	var vnf models.VirtualNetworkFunction
 	if err := r.dbHandle.First(&vnf, "global_id = ? AND status = ?", globalID, models.VNFStatusActive).Error; err != nil {
 		return nil, fmt.Errorf("VNF with global ID %s not found: %w", globalID, err)
@@ -113,7 +65,7 @@ func (r *Registry) FindActiveNetworkFunctionByGlobalID(globalID string) (*models
 	return &vnf, nil
 }
 
-func (r *Registry) FindCompleteActiveNetworkFunctionByGlobalID(globalID string) (*models.VirtualNetworkFunction, error) {
+func (r *InMemoryRegistry) FindCompleteActiveNetworkFunctionByGlobalID(globalID string) (*models.VirtualNetworkFunction, error) {
 	var vnf models.VirtualNetworkFunction
 	if err := r.dbHandle.Preload("Subfunctions").First(&vnf, "global_id = ? AND status = ?", globalID, models.VNFStatusActive).Error; err != nil {
 		return nil, fmt.Errorf("VNF with global ID %s not found: %w", globalID, err)
@@ -121,15 +73,15 @@ func (r *Registry) FindCompleteActiveNetworkFunctionByGlobalID(globalID string) 
 	return &vnf, nil
 }
 
-func (r *Registry) FindVnfInstancesByVNFID(vnfID uint) ([]*models.SimpleVnfInstance, error) {
-	var instances []*models.SimpleVnfInstance
-	if err := r.dbHandle.Find(&instances, "vnf_id = ?", vnfID).Error; err != nil {
-		return nil, fmt.Errorf("failed to find VNF instances for VNF ID %d: %w", vnfID, err)
-	}
-	return instances, nil
-}
+// func (r *InMemoryRegistry) FindVnfInstancesByVNFID(vnfID uint) ([]*models.SimpleVnfInstance, error) {
+// 	var instances []*models.SimpleVnfInstance
+// 	if err := r.dbHandle.Find(&instances, "vnf_id = ?", vnfID).Error; err != nil {
+// 		return nil, fmt.Errorf("failed to find VNF instances for VNF ID %d: %w", vnfID, err)
+// 	}
+// 	return instances, nil
+// }
 
-func (r *Registry) FindVnfInstanceByContainerID(containerID string) (*models.SimpleVnfInstance, error) {
+func (r *InMemoryRegistry) FindVnfInstanceByContainerID(containerID string) (*models.SimpleVnfInstance, error) {
 	var instance models.SimpleVnfInstance
 	if err := r.dbHandle.First(&instance, "container_id = ?", containerID).Error; err != nil {
 		return nil, fmt.Errorf("VNF instance with container ID %s not found: %w", containerID, err)
@@ -137,7 +89,7 @@ func (r *Registry) FindVnfInstanceByContainerID(containerID string) (*models.Sim
 	return &instance, nil
 }
 
-func (r *Registry) FindVnfMultiplexedInstanceByContainerID(containerID string) (*models.MultiplexedVnfInstance, error) {
+func (r *InMemoryRegistry) FindVnfMultiplexedInstanceByContainerID(containerID string) (*models.MultiplexedVnfInstance, error) {
 	var instance models.MultiplexedVnfInstance
 	if err := r.dbHandle.First(&instance, "container_id = ?", containerID).Error; err != nil {
 		return nil, fmt.Errorf("multiplexed VNF instance with container ID %s not found: %w", containerID, err)
@@ -145,15 +97,7 @@ func (r *Registry) FindVnfMultiplexedInstanceByContainerID(containerID string) (
 	return &instance, nil
 }
 
-func (r *Registry) FindVnfGroupByID(id uuid.UUID) (*models.SimpleVnfGroup, error) {
-	var group models.SimpleVnfGroup
-	if err := r.dbHandle.First(&group, "id = ?", id).Error; err != nil {
-		return nil, fmt.Errorf("VNF group with id %s not found: %w", id, err)
-	}
-	return &group, nil
-}
-
-func (r *Registry) FindVnfGroupByIDWithPrepopulatedInstanceList(id uuid.UUID) (*models.SimpleVnfGroup, error) {
+func (r *InMemoryRegistry) FindVnfGroupByIDWithPrepopulatedInstanceList(id uuid.UUID) (*models.SimpleVnfGroup, error) {
 	var group models.SimpleVnfGroup
 	if err := r.dbHandle.Preload("Instances").First(&group, "id = ?", id).Error; err != nil {
 		return nil, fmt.Errorf("VNF group with id %s not found: %w", id, err)
@@ -161,7 +105,7 @@ func (r *Registry) FindVnfGroupByIDWithPrepopulatedInstanceList(id uuid.UUID) (*
 	return &group, nil
 }
 
-func (r *Registry) FindSubfunctionPreloadedVnfMultiplexedGroupByID(id uuid.UUID) (*models.MultiplexedVnfGroup, error) {
+func (r *InMemoryRegistry) FindSubfunctionPreloadedVnfMultiplexedGroupByID(id uuid.UUID) (*models.MultiplexedVnfGroup, error) {
 	var group models.MultiplexedVnfGroup
 	if err := r.dbHandle.Preload("SidAssignments").First(&group, "id = ?", id).Error; err != nil {
 		return nil, fmt.Errorf("multiplexed VNF group with id %s not found: %w", id, err)
@@ -169,7 +113,7 @@ func (r *Registry) FindSubfunctionPreloadedVnfMultiplexedGroupByID(id uuid.UUID)
 	return &group, nil
 }
 
-func (r *Registry) FindVnfMultiplexedGroupByIDWithPrepopulatedInstanceList(id uuid.UUID) (*models.MultiplexedVnfGroup, error) {
+func (r *InMemoryRegistry) FindVnfMultiplexedGroupByIDWithPrepopulatedInstanceList(id uuid.UUID) (*models.MultiplexedVnfGroup, error) {
 	var group models.MultiplexedVnfGroup
 	if err := r.dbHandle.Preload("Instances").First(&group, "id = ?", id).Error; err != nil {
 		return nil, fmt.Errorf("multiplexed VNF group with id %s not found: %w", id, err)
@@ -177,7 +121,7 @@ func (r *Registry) FindVnfMultiplexedGroupByIDWithPrepopulatedInstanceList(id uu
 	return &group, nil
 }
 
-func (r *Registry) FindLocalSimpleVnfGroupByVnfID(globalVnfID string) (*models.SimpleVnfGroup, error) {
+func (r *InMemoryRegistry) FindLocalSimpleVnfGroupByVnfID(globalVnfID string) (*models.SimpleVnfGroup, error) {
 	var group models.SimpleVnfGroup
 	if err := r.dbHandle.Joins("JOIN virtual_network_functions ON virtual_network_functions.id = simple_vnf_groups.vnf_id").Where("virtual_network_functions.global_id = ?", globalVnfID).First(&group).Error; err != nil {
 		return nil, fmt.Errorf("local VNF group with VNF ID %s not found: %w", globalVnfID, err)
@@ -185,7 +129,7 @@ func (r *Registry) FindLocalSimpleVnfGroupByVnfID(globalVnfID string) (*models.S
 	return &group, nil
 }
 
-func (r *Registry) FindLocalMultiplexedGroupByVnfID(globalVnfID string) (*models.MultiplexedVnfGroup, error) {
+func (r *InMemoryRegistry) FindLocalMultiplexedGroupByVnfID(globalVnfID string) (*models.MultiplexedVnfGroup, error) {
 	var group models.MultiplexedVnfGroup
 	if err := r.dbHandle.Joins("JOIN virtual_network_functions ON virtual_network_functions.id = multiplexed_vnf_groups.vnf_id").Where("virtual_network_functions.global_id = ?", globalVnfID).First(&group).Error; err != nil {
 		return nil, fmt.Errorf("local multiplexed VNF group with VNF ID %s not found: %w", globalVnfID, err)
@@ -193,7 +137,7 @@ func (r *Registry) FindLocalMultiplexedGroupByVnfID(globalVnfID string) (*models
 	return &group, nil
 }
 
-func (r *Registry) FindAllNetworkServiceChains() ([]models.ServiceChain, error) {
+func (r *InMemoryRegistry) FindAllNetworkServiceChains() ([]models.ServiceChain, error) {
 	var chains []models.ServiceChain
 	if err := r.dbHandle.Preload("Elements").Find(&chains).Error; err != nil {
 		return nil, fmt.Errorf("failed to find all network service chains: %w", err)
@@ -201,7 +145,7 @@ func (r *Registry) FindAllNetworkServiceChains() ([]models.ServiceChain, error) 
 	return chains, nil
 }
 
-func (r *Registry) FindActiveNetworkServiceChainByGlobalID(globalChainID string) (*models.ServiceChain, error) {
+func (r *InMemoryRegistry) FindActiveNetworkServiceChainByGlobalID(globalChainID string) (*models.ServiceChain, error) {
 	var chain models.ServiceChain
 	if err := r.dbHandle.First(&chain, "global_id = ? AND status = ?", globalChainID, models.ServiceChainStatusActive).Error; err != nil {
 		return nil, fmt.Errorf("network service chain with global ID %s not found: %w", globalChainID, err)
@@ -209,7 +153,7 @@ func (r *Registry) FindActiveNetworkServiceChainByGlobalID(globalChainID string)
 	return &chain, nil
 }
 
-func (r *Registry) FindActiveNodeByGlobalID(globalNodeID string) (*models.Worker, error) {
+func (r *InMemoryRegistry) FindActiveNodeByGlobalID(globalNodeID string) (*models.Worker, error) {
 	var node models.Worker
 	if err := r.dbHandle.First(&node, "global_id = ? AND status = ?", globalNodeID, models.WorkerStatusActive).Error; err != nil {
 		return nil, fmt.Errorf("node with global ID %s not found: %w", globalNodeID, err)
@@ -217,7 +161,7 @@ func (r *Registry) FindActiveNodeByGlobalID(globalNodeID string) (*models.Worker
 	return &node, nil
 }
 
-func (r *Registry) FindRemoteAppGroupByNodeAndExternalID(nodeID string, groupID string) (*models.RemoteAppGroup, error) {
+func (r *InMemoryRegistry) FindRemoteAppGroupByNodeAndExternalID(nodeID string, groupID string) (*models.RemoteAppGroup, error) {
 	var group models.RemoteAppGroup
 	if err := r.dbHandle.First(&group, "node_id = ? AND external_group_id = ?", nodeID, groupID).Error; err != nil {
 		return nil, fmt.Errorf("remote app group with node ID %s and external ID %s not found: %w", nodeID, groupID, err)
@@ -225,7 +169,7 @@ func (r *Registry) FindRemoteAppGroupByNodeAndExternalID(nodeID string, groupID 
 	return &group, nil
 }
 
-func (r *Registry) FindRemoteVnfGroupByNodeAndExternalID(nodeID string, groupID string) (*models.RemoteVnfGroup, error) {
+func (r *InMemoryRegistry) FindRemoteVnfGroupByNodeAndExternalID(nodeID string, groupID string) (*models.RemoteVnfGroup, error) {
 	var group models.RemoteVnfGroup
 	if err := r.dbHandle.First(&group, "node_id = ? AND external_group_id = ?", nodeID, groupID).Error; err != nil {
 		return nil, fmt.Errorf("remote VNF group with node ID %s and external ID %s not found: %w", nodeID, groupID, err)
@@ -233,35 +177,35 @@ func (r *Registry) FindRemoteVnfGroupByNodeAndExternalID(nodeID string, groupID 
 	return &group, nil
 }
 
-func (r *Registry) SaveApp(app *models.Application) error {
+func (r *InMemoryRegistry) SaveApp(app *models.Application) error {
 	if err := r.dbHandle.Save(app).Error; err != nil {
 		return fmt.Errorf("failed to save application: %w", err)
 	}
 	return nil
 }
 
-func (r *Registry) SaveAppGroup(group *models.AppGroup) error {
+func (r *InMemoryRegistry) SaveAppGroup(group *models.AppGroup) error {
 	if err := r.dbHandle.Save(group).Error; err != nil {
 		return fmt.Errorf("failed to save app group: %w", err)
 	}
 	return nil
 }
 
-func (r *Registry) SaveAppInstance(instance *models.AppInstance) error {
+func (r *InMemoryRegistry) SaveAppInstance(instance *models.AppInstance) error {
 	if err := r.dbHandle.Save(instance).Error; err != nil {
 		return fmt.Errorf("failed to save app instance: %w", err)
 	}
 	return nil
 }
 
-func (r *Registry) SaveVnf(function *models.VirtualNetworkFunction) error {
+func (r *InMemoryRegistry) SaveVnf(function *models.VirtualNetworkFunction) error {
 	if err := r.dbHandle.Save(function).Error; err != nil {
 		return fmt.Errorf("failed to save virtual network function: %w", err)
 	}
 	return nil
 }
 
-func (r *Registry) SaveSubfunctions(subfunctions []models.Subfunction) error {
+func (r *InMemoryRegistry) SaveSubfunctions(subfunctions []models.Subfunction) error {
 	logger.DebugLogger().Printf("Saving %d subfunctions", len(subfunctions))
 	for _, sf := range subfunctions {
 		logger.DebugLogger().Printf("Saving subfunction: %+v", sf)
@@ -272,230 +216,142 @@ func (r *Registry) SaveSubfunctions(subfunctions []models.Subfunction) error {
 	return nil
 }
 
-func (r *Registry) SaveVnfGroup(group *models.SimpleVnfGroup) error {
+func (r *InMemoryRegistry) SaveVnfGroup(group *models.SimpleVnfGroup) error {
 	if err := r.dbHandle.Save(group).Error; err != nil {
 		return fmt.Errorf("failed to save VNF group: %w", err)
 	}
 	return nil
 }
 
-func (r *Registry) SaveVnfMultiplexedGroup(group *models.MultiplexedVnfGroup) error {
+func (r *InMemoryRegistry) SaveVnfMultiplexedGroup(group *models.MultiplexedVnfGroup) error {
 	if err := r.dbHandle.Save(group).Error; err != nil {
 		return fmt.Errorf("failed to save multiplexed VNF group: %w", err)
 	}
 	return nil
 }
 
-func (r *Registry) SaveSidAssignments(assignments []models.SidAssignment) error {
-	for _, assignment := range assignments {
-		if err := r.dbHandle.Save(&assignment).Error; err != nil {
-			return fmt.Errorf("failed to save SID assignment: %w", err)
-		}
-	}
-	return nil
-}
+// func (r *InMemoryRegistry) SaveSidAssignments(assignments []models.SidAssignment) error {
+// 	for _, assignment := range assignments {
+// 		if err := r.dbHandle.Save(&assignment).Error; err != nil {
+// 			return fmt.Errorf("failed to save SID assignment: %w", err)
+// 		}
+// 	}
+// 	return nil
+// }
 
-func (r *Registry) SaveVnfInstance(instance *models.SimpleVnfInstance) error {
+func (r *InMemoryRegistry) SaveVnfInstance(instance *models.SimpleVnfInstance) error {
 	if err := r.dbHandle.Save(instance).Error; err != nil {
 		return fmt.Errorf("failed to save VNF instance: %w", err)
 	}
 	return nil
 }
 
-func (r *Registry) SaveVnfMultiplexedInstance(instance *models.MultiplexedVnfInstance) error {
+func (r *InMemoryRegistry) SaveVnfMultiplexedInstance(instance *models.MultiplexedVnfInstance) error {
 	if err := r.dbHandle.Save(instance).Error; err != nil {
 		return fmt.Errorf("failed to save multiplexed VNF instance: %w", err)
 	}
 	return nil
 }
 
-func (r *Registry) SaveNetworkServiceChain(chain *models.ServiceChain) error {
+func (r *InMemoryRegistry) SaveNetworkServiceChain(chain *models.ServiceChain) error {
 	if err := r.dbHandle.Save(chain).Error; err != nil {
 		return fmt.Errorf("failed to save network service chain: %w", err)
 	}
 	return nil
 }
 
-func (r *Registry) SaveChainElement(element *models.ServiceChainVnfs) error {
-	if err := r.dbHandle.Save(element).Error; err != nil {
-		return fmt.Errorf("failed to save chain element: %w", err)
-	}
-	return nil
-}
-
-func (r *Registry) SaveRoute(route *models.Route) error {
-	if err := r.dbHandle.Save(route).Error; err != nil {
-		return fmt.Errorf("failed to save route: %w", err)
-	}
-	return nil
-}
-
-func (r *Registry) SaveRemoteAppInstances(instances []*models.RemoteAppInstance) error {
-	for _, instance := range instances {
-		if err := r.dbHandle.Save(instance).Error; err != nil {
-			return fmt.Errorf("failed to save remote app instance: %w", err)
-		}
-	}
-	return nil
-}
-
-func (r *Registry) RemoveAppInstanceByContainerID(containerID string) error {
-	if err := r.dbHandle.Delete(&models.AppInstance{}, "container_id = ?", containerID).Error; err != nil {
-		return fmt.Errorf("failed to remove app instance with container ID %s: %w", containerID, err)
-	}
-	return nil
-}
-
-func (r *Registry) RemoveAppInstance(id uuid.UUID) error {
+func (r *InMemoryRegistry) RemoveAppInstance(id uuid.UUID) error {
 	if err := r.dbHandle.Delete(&models.AppInstance{}, "id = ?", id).Error; err != nil {
 		return fmt.Errorf("failed to remove app instance with ID %s: %w", id, err)
 	}
 	return nil
 }
 
-func (r *Registry) RemoveAppGroup(id uuid.UUID) error {
+func (r *InMemoryRegistry) RemoveAppGroup(id uuid.UUID) error {
 	if err := r.dbHandle.Delete(&models.AppGroup{}, "id = ?", id).Error; err != nil {
 		return fmt.Errorf("failed to remove app group with ID %s: %w", id, err)
 	}
 	return nil
 }
 
-func (r *Registry) RemoveVnfInstance(id uuid.UUID) error {
+func (r *InMemoryRegistry) RemoveVnfInstance(id uuid.UUID) error {
 	if err := r.dbHandle.Delete(&models.SimpleVnfInstance{}, "id = ?", id).Error; err != nil {
 		return fmt.Errorf("failed to delete VNF instance %s: %w", id, err)
 	}
 	return nil
 }
 
-func (r *Registry) RemoveVnfMultiplexedInstance(id uuid.UUID) error {
+func (r *InMemoryRegistry) RemoveVnfMultiplexedInstance(id uuid.UUID) error {
 	if err := r.dbHandle.Delete(&models.MultiplexedVnfInstance{}, "id = ?", id).Error; err != nil {
 		return fmt.Errorf("failed to delete multiplexed VNF instance %s: %w", id, err)
 	}
 	return nil
 }
 
-func (r *Registry) RemoveVnfGroup(id uuid.UUID) error {
+func (r *InMemoryRegistry) RemoveVnfGroup(id uuid.UUID) error {
 	if err := r.dbHandle.Delete(&models.SimpleVnfGroup{}, "id = ?", id).Error; err != nil {
 		return fmt.Errorf("failed to remove VNF group with ID %s: %w", id, err)
 	}
 	return nil
 }
 
-func (r *Registry) RemoveVnfMultiplexedGroup(id uuid.UUID) error {
+func (r *InMemoryRegistry) RemoveVnfMultiplexedGroup(id uuid.UUID) error {
 	if err := r.dbHandle.Delete(&models.MultiplexedVnfGroup{}, "id = ?", id).Error; err != nil {
 		return fmt.Errorf("failed to remove multiplexed VNF group with ID %s: %w", id, err)
 	}
 	return nil
 }
 
-func (r *Registry) RemoveVnfInstanceByContainerID(containerID string) error {
-	if err := r.dbHandle.Delete(&models.SimpleVnfInstance{}, "container_id = ?", containerID).Error; err != nil {
-		return fmt.Errorf("failed to remove VNF instance with container ID %s: %w", containerID, err)
-	}
-	return nil
-}
-
-// func (r *Registry) FindAllRoutes() ([]*models.Route, error) {
-// 	var routes []*models.Route
-// 	if err := r.dbHandle.Find(&routes).Error; err != nil {
-// 		return nil, fmt.Errorf("failed to find all routes: %w", err)
-// 	}
-// 	return routes, nil
-// }
-
-// func (r *Registry) FindRouteStages(route *models.Route) ([]models.VnfGroup, error) {
-// 	groups, err := route.GetStagedGroups(r.dbHandle)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to get staged groups for route %s: %w", route.ID, err)
-// 	}
-// 	return groups, nil
-// }
-
-// func (r *Registry) RemoveAllRoutes() error {
-// 	if err := r.dbHandle.Delete(&models.Route{}, "1 = 1").Error; err != nil {
-// 		return fmt.Errorf("failed to remove all routes: %w", err)
-// 	}
-// 	return nil
-// }
-
-func (r *Registry) RemoveRemoteAppGroupsByID(ids []uuid.UUID) error {
-	if len(ids) == 0 {
-		return nil
-	}
-	if err := r.dbHandle.Delete(&models.RemoteAppGroup{}, "id IN ?", ids).Error; err != nil {
-		return fmt.Errorf("failed to remove remote app groups by IDs %v: %w", ids, err)
-	}
-	return nil
-}
-
-// func (r *Registry) SaveRoutes(routes []*models.Route) error {
-// 	for _, route := range routes {
-// 		if err := r.SaveRoute(route); err != nil {
-// 			return fmt.Errorf("failed to save route: %w", err)
-// 		}
-// 	}
-// 	return nil
-// }
-
-func (r *Registry) SaveRouteStages(routeStages []*models.RouteStage) error {
-	for _, stage := range routeStages {
-		if err := r.dbHandle.Save(stage).Error; err != nil {
-			return fmt.Errorf("failed to save route stage: %w", err)
-		}
-	}
-	return nil
-}
-
-func (r *Registry) SaveRemoteAppGroup(group *models.RemoteAppGroup) error {
+func (r *InMemoryRegistry) SaveRemoteAppGroup(group *models.RemoteAppGroup) error {
 	if err := r.dbHandle.Save(group).Error; err != nil {
 		return fmt.Errorf("failed to save remote app group: %w", err)
 	}
 	return nil
 }
 
-func (r *Registry) SaveRemoteVnfGroup(group *models.RemoteVnfGroup) error {
+func (r *InMemoryRegistry) SaveRemoteVnfGroup(group *models.RemoteVnfGroup) error {
 	if err := r.dbHandle.Save(group).Error; err != nil {
 		return fmt.Errorf("failed to save remote VNF group: %w", err)
 	}
 	return nil
 }
 
-func (r *Registry) SaveNode(node *models.Worker) error {
+func (r *InMemoryRegistry) SaveNode(node *models.Worker) error {
 	if err := r.dbHandle.Save(node).Error; err != nil {
 		return fmt.Errorf("failed to save node: %w", err)
 	}
 	return nil
 }
 
-func (r *Registry) MarkAppAsDeleted(globalID string) error {
+func (r *InMemoryRegistry) MarkAppAsDeleted(globalID string) error {
 	if err := r.dbHandle.Model(&models.Application{}).Where("global_id = ? AND status = ?", globalID, models.AppStatusActive).Update("status", models.AppStatusDeletionPending).Error; err != nil {
 		return fmt.Errorf("failed to mark application %s as deleted: %w", globalID, err)
 	}
 	return nil
 }
 
-func (r *Registry) MarkVnfAsDeleted(globalID string) error {
+func (r *InMemoryRegistry) MarkVnfAsDeleted(globalID string) error {
 	if err := r.dbHandle.Model(&models.VirtualNetworkFunction{}).Where("global_id = ? AND status = ?", globalID, models.VNFStatusActive).Update("status", models.VNFStatusDeletionPending).Error; err != nil {
 		return fmt.Errorf("failed to mark VNF %s as deleted: %w", globalID, err)
 	}
 	return nil
 }
 
-func (r *Registry) MarkServiceChainAsDeleted(globalID string) error {
+func (r *InMemoryRegistry) MarkServiceChainAsDeleted(globalID string) error {
 	if err := r.dbHandle.Model(&models.ServiceChain{}).Where("global_id = ? AND status = ?", globalID, models.ServiceChainStatusActive).Update("status", models.ServiceChainStatusDeletionPending).Error; err != nil {
 		return fmt.Errorf("failed to mark service chain %s as deleted: %w", globalID, err)
 	}
 	return nil
 }
 
-func (r *Registry) MarkNodeAsDeleted(globalID string) error {
+func (r *InMemoryRegistry) MarkNodeAsDeleted(globalID string) error {
 	if err := r.dbHandle.Model(&models.Worker{}).Where("global_id = ? AND status = ?", globalID, models.WorkerStatusActive).Update("status", models.WorkerStatusInactive).Error; err != nil {
 		return fmt.Errorf("failed to mark node %s as deleted: %w", globalID, err)
 	}
 	return nil
 }
 
-func (r *Registry) RemoveRemoteAppInstancesByIP(ips []string, groupID uuid.UUID) error {
+func (r *InMemoryRegistry) RemoveRemoteAppInstancesByIP(ips []string, groupID uuid.UUID) error {
 	if len(ips) == 0 {
 		return nil
 	}
@@ -505,14 +361,14 @@ func (r *Registry) RemoveRemoteAppInstancesByIP(ips []string, groupID uuid.UUID)
 	return nil
 }
 
-func (r *Registry) RemoveRemoteAppGroupsByGlobalAppID(globalAppID string) error {
+func (r *InMemoryRegistry) RemoveRemoteAppGroupsByGlobalAppID(globalAppID string) error {
 	if err := r.dbHandle.Delete(&models.RemoteAppGroup{}, "app_id = ?", globalAppID).Error; err != nil {
 		return fmt.Errorf("failed to remove remote app groups for App ID %s: %w", globalAppID, err)
 	}
 	return nil
 }
 
-func (r *Registry) RemoveRemoteVnfGroupsByGlobalVnfID(globalVnfID string) error {
+func (r *InMemoryRegistry) RemoveRemoteVnfGroupsByGlobalVnfID(globalVnfID string) error {
 	if err := r.dbHandle.Delete(&models.RemoteVnfGroup{}, "vnf_id = ?", globalVnfID).Error; err != nil {
 		return fmt.Errorf("failed to remove remote VNF groups for VNF ID %s: %w", globalVnfID, err)
 	}

--- a/go-daemon/db/types.go
+++ b/go-daemon/db/types.go
@@ -1,12 +1,59 @@
 package db
 
 import (
-	"gorm.io/gorm"
+	"iml-daemon/models"
+
+	"github.com/google/uuid"
 )
 
-// Registry is the main entrypoint to accessing the database.
-// It provides methods to find applications, app instances, VNFs, and VNF instances.
-// It uses GORM for database operations.
-type Registry struct {
-	dbHandle *gorm.DB
+type Registry interface {
+	FindActiveAppByLocalID(localID uuid.UUID) (*models.Application, error)
+	FindActiveAppByGlobalID(globalID string) (*models.Application, error)
+	FindLocalAppGroupByGlobalID(globalAppID string) (*models.AppGroup, error)
+	FindAppGroupByID(id uuid.UUID) (*models.AppGroup, error)
+	FindAppInstanceByContainerID(containerID string) (*models.AppInstance, error)
+	FindActiveNetworkFunctionByLocalID(localID uuid.UUID) (*models.VirtualNetworkFunction, error)
+	FindActiveNetworkFunctionByGlobalID(globalID string) (*models.VirtualNetworkFunction, error)
+	FindCompleteActiveNetworkFunctionByGlobalID(globalID string) (*models.VirtualNetworkFunction, error)
+	FindVnfInstanceByContainerID(containerID string) (*models.SimpleVnfInstance, error)
+	FindVnfMultiplexedInstanceByContainerID(containerID string) (*models.MultiplexedVnfInstance, error)
+	FindVnfGroupByIDWithPrepopulatedInstanceList(id uuid.UUID) (*models.SimpleVnfGroup, error)
+	FindSubfunctionPreloadedVnfMultiplexedGroupByID(id uuid.UUID) (*models.MultiplexedVnfGroup, error)
+	FindVnfMultiplexedGroupByIDWithPrepopulatedInstanceList(id uuid.UUID) (*models.MultiplexedVnfGroup, error)
+	FindLocalSimpleVnfGroupByVnfID(globalVnfID string) (*models.SimpleVnfGroup, error)
+	FindLocalMultiplexedGroupByVnfID(globalVnfID string) (*models.MultiplexedVnfGroup, error)
+	FindAllNetworkServiceChains() ([]models.ServiceChain, error)
+	FindActiveNetworkServiceChainByGlobalID(globalChainID string) (*models.ServiceChain, error)
+	FindActiveNodeByGlobalID(globalNodeID string) (*models.Worker, error)
+	FindRemoteAppGroupByNodeAndExternalID(nodeID string, groupID string) (*models.RemoteAppGroup, error)
+	FindRemoteVnfGroupByNodeAndExternalID(nodeID string, groupID string) (*models.RemoteVnfGroup, error)
+	SaveApp(app *models.Application) error
+	SaveAppGroup(group *models.AppGroup) error
+	SaveAppInstance(instance *models.AppInstance) error
+	SaveVnf(function *models.VirtualNetworkFunction) error
+	SaveSubfunctions(subfunctions []models.Subfunction) error
+	SaveVnfGroup(group *models.SimpleVnfGroup) error
+	SaveVnfMultiplexedGroup(group *models.MultiplexedVnfGroup) error
+	SaveVnfInstance(instance *models.SimpleVnfInstance) error
+	SaveVnfMultiplexedInstance(instance *models.MultiplexedVnfInstance) error
+	SaveNetworkServiceChain(chain *models.ServiceChain) error
+	RemoveAppInstance(id uuid.UUID) error
+	RemoveAppGroup(id uuid.UUID) error
+	RemoveVnfInstance(id uuid.UUID) error
+	RemoveVnfMultiplexedInstance(id uuid.UUID) error
+	RemoveVnfGroup(id uuid.UUID) error
+	RemoveVnfMultiplexedGroup(id uuid.UUID) error
+	SaveRemoteAppGroup(group *models.RemoteAppGroup) error
+	SaveRemoteVnfGroup(group *models.RemoteVnfGroup) error
+	SaveNode(node *models.Worker) error
+	MarkAppAsDeleted(globalID string) error
+	MarkVnfAsDeleted(globalID string) error
+	MarkServiceChainAsDeleted(globalID string) error
+	MarkNodeAsDeleted(globalID string) error
+	RemoveRemoteAppInstancesByIP(ips []string, groupID uuid.UUID) error
+	RemoveRemoteAppGroupsByGlobalAppID(globalAppID string) error
+	RemoveRemoteVnfGroupsByGlobalVnfID(globalVnfID string) error
 }
+
+
+

--- a/go-daemon/go.mod
+++ b/go-daemon/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/r3labs/diff v1.1.0
+	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.1
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.0
@@ -41,6 +42,8 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect

--- a/go-daemon/internal/testutil/dataplane_mgr_mock.go
+++ b/go-daemon/internal/testutil/dataplane_mgr_mock.go
@@ -1,0 +1,51 @@
+package testutil
+
+import (
+	"iml-daemon/services/router/dataplane"
+	"net"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockDataplaneManager struct {
+	mock.Mock
+}
+func (mgr *MockDataplaneManager) Close() error {
+	args := mgr.Called()
+	return args.Error(0)
+}
+func (mgr *MockDataplaneManager) AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (dataplane.VNFSubnet, error) {
+	args := mgr.Called(vnfGroupID, sidAmount)
+	return args.Get(0).(dataplane.VNFSubnet), args.Error(1)
+}
+func (mgr *MockDataplaneManager) AddApplicationSubnet(appGroupID uuid.UUID) (dataplane.AppSubnet, error) {
+	args := mgr.Called(appGroupID)
+	return args.Get(0).(dataplane.AppSubnet), args.Error(1)
+}
+func (mgr *MockDataplaneManager) RemoveApplicationSubnet(appGroupID uuid.UUID) {}
+func (mgr *MockDataplaneManager) RemoveVNFSubnet(vnfGroupID uuid.UUID) {}
+func (mgr *MockDataplaneManager) AddApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) (*net.IPNet, string, error) {
+	args := mgr.Called(appGroupID, appInstanceID)
+	return args.Get(0).(*net.IPNet), args.String(1), args.Error(2)
+}
+func (mgr *MockDataplaneManager) RemoveApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) error {
+	args := mgr.Called(appGroupID, appInstanceID)
+	return args.Error(0)
+}
+func (mgr *MockDataplaneManager) AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) (*net.IPNet, string, error) {
+	args := mgr.Called(vnfGroupID, vnfInstanceID)
+	return args.Get(0).(*net.IPNet), args.String(1), args.Error(2)
+}
+func (mgr *MockDataplaneManager) RemoveVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) error {
+	args := mgr.Called(vnfGroupID, vnfInstanceID)
+	return args.Error(0)
+}
+func (mgr *MockDataplaneManager) AddRoute(srcAppGroup uuid.UUID, dstNet net.IPNet, sids []net.IP) error {
+	args := mgr.Called(srcAppGroup, dstNet, sids)
+	return args.Error(0)
+}
+func (mgr *MockDataplaneManager) RemoveRoute(srcAppGroup uuid.UUID, dstNet string) error {
+	args := mgr.Called(srcAppGroup, dstNet)
+	return args.Error(0)
+}

--- a/go-daemon/internal/testutil/db_registry_mock.go
+++ b/go-daemon/internal/testutil/db_registry_mock.go
@@ -1,0 +1,196 @@
+package testutil
+
+import (
+	"iml-daemon/models"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockRepo struct {
+	mock.Mock
+}
+func (r *MockRepo) FindActiveAppByLocalID(localID uuid.UUID) (*models.Application, error) {
+	args := r.Called(localID)
+	return args.Get(0).(*models.Application), args.Error(1)
+}
+func (r *MockRepo) FindActiveAppByGlobalID(globalID string) (*models.Application, error) {
+	args := r.Called(globalID)
+	return args.Get(0).(*models.Application), args.Error(1)
+}
+func (r *MockRepo) FindLocalAppGroupByGlobalID(globalAppID string) (*models.AppGroup, error) {
+	args := r.Called(globalAppID)
+	return args.Get(0).(*models.AppGroup), args.Error(1)
+}
+func (r *MockRepo) FindAppGroupByID(id uuid.UUID) (*models.AppGroup, error) {
+	args := r.Called(id)
+	return args.Get(0).(*models.AppGroup), args.Error(1)
+}
+func (r *MockRepo) FindAppInstanceByContainerID(containerID string) (*models.AppInstance, error) {
+	args := r.Called(containerID)
+	return args.Get(0).(*models.AppInstance), args.Error(1)
+}
+func (r *MockRepo) FindActiveNetworkFunctionByLocalID(localID uuid.UUID) (*models.VirtualNetworkFunction, error) {
+	args := r.Called(localID)
+	return args.Get(0).(*models.VirtualNetworkFunction), args.Error(1)
+}
+func (r *MockRepo) FindActiveNetworkFunctionByGlobalID(globalID string) (*models.VirtualNetworkFunction, error) {
+	args := r.Called(globalID)
+	return args.Get(0).(*models.VirtualNetworkFunction), args.Error(1)
+}
+func (r *MockRepo) FindCompleteActiveNetworkFunctionByGlobalID(globalID string) (*models.VirtualNetworkFunction, error) {
+	args := r.Called(globalID)
+	return args.Get(0).(*models.VirtualNetworkFunction), args.Error(1)
+}
+func (r *MockRepo) FindVnfInstanceByContainerID(containerID string) (*models.SimpleVnfInstance, error) {
+	args := r.Called(containerID)
+	return args.Get(0).(*models.SimpleVnfInstance), args.Error(1)
+}
+func (r *MockRepo) FindVnfMultiplexedInstanceByContainerID(containerID string) (*models.MultiplexedVnfInstance, error) {
+	args := r.Called(containerID)
+	return args.Get(0).(*models.MultiplexedVnfInstance), args.Error(1)
+}
+func (r *MockRepo) FindVnfGroupByIDWithPrepopulatedInstanceList(id uuid.UUID) (*models.SimpleVnfGroup, error) {
+	args := r.Called(id)
+	return args.Get(0).(*models.SimpleVnfGroup), args.Error(1)
+}
+func (r *MockRepo) FindSubfunctionPreloadedVnfMultiplexedGroupByID(id uuid.UUID) (*models.MultiplexedVnfGroup, error) {
+	args := r.Called(id)
+	return args.Get(0).(*models.MultiplexedVnfGroup), args.Error(1)
+}
+func (r *MockRepo) FindVnfMultiplexedGroupByIDWithPrepopulatedInstanceList(id uuid.UUID) (*models.MultiplexedVnfGroup, error) {
+	args := r.Called(id)
+	return args.Get(0).(*models.MultiplexedVnfGroup), args.Error(1)
+}
+func (r *MockRepo) FindLocalSimpleVnfGroupByVnfID(globalVnfID string) (*models.SimpleVnfGroup, error) {
+	args := r.Called(globalVnfID)
+	return args.Get(0).(*models.SimpleVnfGroup), args.Error(1)
+}
+func (r *MockRepo) FindLocalMultiplexedGroupByVnfID(globalVnfID string) (*models.MultiplexedVnfGroup, error) {
+	args := r.Called(globalVnfID)
+	return args.Get(0).(*models.MultiplexedVnfGroup), args.Error(1)
+}
+func (r *MockRepo) FindAllNetworkServiceChains() ([]models.ServiceChain, error) {
+	args := r.Called()
+	return args.Get(0).([]models.ServiceChain), args.Error(1)
+}
+func (r *MockRepo) FindActiveNetworkServiceChainByGlobalID(globalChainID string) (*models.ServiceChain, error) {
+	args := r.Called(globalChainID)
+	return args.Get(0).(*models.ServiceChain), args.Error(1)
+}
+func (r *MockRepo) FindActiveNodeByGlobalID(globalNodeID string) (*models.Worker, error) {
+	args := r.Called(globalNodeID)
+	return args.Get(0).(*models.Worker), args.Error(1)
+}
+func (r *MockRepo) FindRemoteAppGroupByNodeAndExternalID(nodeID string, groupID string) (*models.RemoteAppGroup, error) {
+	args := r.Called(nodeID, groupID)
+	return args.Get(0).(*models.RemoteAppGroup), args.Error(1)
+}
+func (r *MockRepo) FindRemoteVnfGroupByNodeAndExternalID(nodeID string, groupID string) (*models.RemoteVnfGroup, error) {
+	args := r.Called(nodeID, groupID)
+	return args.Get(0).(*models.RemoteVnfGroup), args.Error(1)
+}
+func (r *MockRepo) SaveApp(app *models.Application) error {
+	args := r.Called(app)
+	return args.Error(0)
+}
+func (r *MockRepo) SaveAppGroup(group *models.AppGroup) error {
+	args := r.Called(group)
+	return args.Error(0)
+}
+func (r *MockRepo) SaveAppInstance(instance *models.AppInstance) error {
+	args := r.Called(instance)
+	return args.Error(0)
+}
+func (r *MockRepo) SaveVnf(function *models.VirtualNetworkFunction) error {
+	args := r.Called(function)
+	return args.Error(0)
+}
+func (r *MockRepo) SaveSubfunctions(subfunctions []models.Subfunction) error {
+	args := r.Called(subfunctions)
+	return args.Error(0)
+}
+func (r *MockRepo) SaveVnfGroup(group *models.SimpleVnfGroup) error {
+	args := r.Called(group)
+	return args.Error(0)
+}
+func (r *MockRepo) SaveVnfMultiplexedGroup(group *models.MultiplexedVnfGroup) error {
+	args := r.Called(group)
+	return args.Error(0)
+}
+func (r *MockRepo) SaveVnfInstance(instance *models.SimpleVnfInstance) error {
+	args := r.Called(instance)
+	return args.Error(0)
+}
+func (r *MockRepo) SaveVnfMultiplexedInstance(instance *models.MultiplexedVnfInstance) error {
+	args := r.Called(instance)
+	return args.Error(0)
+}
+func (r *MockRepo) SaveNetworkServiceChain(chain *models.ServiceChain) error {
+	args := r.Called(chain)
+	return args.Error(0)
+}
+func (r *MockRepo) RemoveAppInstance(id uuid.UUID) error {
+	args := r.Called(id)
+	return args.Error(0)
+}
+func (r *MockRepo) RemoveAppGroup(id uuid.UUID) error {
+	args := r.Called(id)
+	return args.Error(0)
+}
+func (r *MockRepo) RemoveVnfInstance(id uuid.UUID) error {
+	args := r.Called(id)
+	return args.Error(0)
+}
+func (r *MockRepo) RemoveVnfMultiplexedInstance(id uuid.UUID) error {
+	args := r.Called(id)
+	return args.Error(0)
+}
+func (r *MockRepo) RemoveVnfGroup(id uuid.UUID) error {
+	args := r.Called(id)
+	return args.Error(0)
+}
+func (r *MockRepo) RemoveVnfMultiplexedGroup(id uuid.UUID) error {
+	args := r.Called(id)
+	return args.Error(0)
+}
+func (r *MockRepo) SaveRemoteAppGroup(group *models.RemoteAppGroup) error {
+	args := r.Called(group)
+	return args.Error(0)
+}
+func (r *MockRepo) SaveRemoteVnfGroup(group *models.RemoteVnfGroup) error {
+	args := r.Called(group)
+	return args.Error(0)
+}
+func (r *MockRepo) SaveNode(node *models.Worker) error {
+	args := r.Called(node)
+	return args.Error(0)
+}
+func (r *MockRepo) MarkAppAsDeleted(globalID string) error {
+	args := r.Called(globalID)
+	return args.Error(0)
+}
+func (r *MockRepo) MarkVnfAsDeleted(globalID string) error {
+	args := r.Called(globalID)
+	return args.Error(0)
+}
+func (r *MockRepo) MarkServiceChainAsDeleted(globalID string) error {
+	args := r.Called(globalID)
+	return args.Error(0)
+}
+func (r *MockRepo) MarkNodeAsDeleted(globalID string) error {
+	args := r.Called(globalID)
+	return args.Error(0)
+}
+func (r *MockRepo) RemoveRemoteAppInstancesByIP(ips []string, groupID uuid.UUID) error {
+	args := r.Called(ips, groupID)
+	return args.Error(0)
+}
+func (r *MockRepo) RemoveRemoteAppGroupsByGlobalAppID(globalAppID string) error {
+	args := r.Called(globalAppID)
+	return args.Error(0)
+}
+func (r *MockRepo) RemoveRemoteVnfGroupsByGlobalVnfID(globalVnfID string) error {
+	args := r.Called(globalVnfID)
+	return args.Error(0)
+}

--- a/go-daemon/internal/testutil/events_bus_mock.go
+++ b/go-daemon/internal/testutil/events_bus_mock.go
@@ -1,0 +1,21 @@
+package testutil
+
+import (
+	"iml-daemon/services/events"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockEventBus struct {
+	mock.Mock
+}
+func (eb *MockEventBus) Subscribe(eventName string, handler events.Handler) uint64 {
+	args := eb.Called(eventName, handler)
+	return args.Get(0).(uint64)
+}
+func (eb *MockEventBus) Unsubscribe(eventName string, id uint64) {
+	eb.Called(eventName, id)
+}
+func (eb *MockEventBus) Publish(event events.Event) {
+	eb.Called(event)
+}

--- a/go-daemon/internal/testutil/iml_client_mock.go
+++ b/go-daemon/internal/testutil/iml_client_mock.go
@@ -1,0 +1,19 @@
+package testutil
+
+import (
+	"iml-daemon/models"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockIMLClient struct {
+	mock.Mock
+}
+func (m *MockIMLClient) GetApplication(id string) (*models.Application, error) {
+	args := m.Called(id)
+	return args.Get(0).(*models.Application), args.Error(1)
+}
+func (m *MockIMLClient) GetNetworkFunction(id string) (*models.VirtualNetworkFunction, error) {
+	args := m.Called(id)
+	return args.Get(0).(*models.VirtualNetworkFunction), args.Error(1)
+}

--- a/go-daemon/main.go
+++ b/go-daemon/main.go
@@ -14,6 +14,7 @@ import (
 	"iml-daemon/services/iml/subscriptions"
 	"iml-daemon/services/routecalc"
 	"iml-daemon/services/router"
+	"iml-daemon/services/router/dataplane"
 	"iml-daemon/vnfs"
 	"os"
 	"os/signal"
@@ -39,10 +40,10 @@ func main() {
 	}
 
 	// Initialize the event bus
-	eb := events.NewEventBus()
+	eb := events.NewInMemory()
 
 	// Initialize the Dataplane
-	dataplane, err := router.NewDataplane(config.SIDSubnet, config.AppSubnet, config.NFSubnet, config.TunSubnet)
+	dataplaneMgr, err := dataplane.NewSoftware(config.SIDSubnet, config.AppSubnet, config.NFSubnet, config.TunSubnet)
 	if err != nil {
 		logger.ErrorLogger().Printf("Failed to create Dataplane: %v", err)
 		panic("Failed to create Dataplane: " + err.Error())
@@ -134,19 +135,19 @@ func main() {
 	}
 
 	// Initialize the router service
-	routerService, err := router.New(registry, eb, dataplane)
+	routerService, err := router.New(registry, eb, dataplaneMgr)
 	if err != nil {
 		logger.ErrorLogger().Printf("Failed to initialize RouterService: %v", err)
 		panic("Failed to initialize RouterService: " + err.Error())
 	}
 
 	// Create app and vnf instance factories
-	appFactory, err := apps.NewInstanceFactory(registry, eb, dataplane, imlClient)
+	appFactory, err := apps.NewInstanceFactory(registry, eb, dataplaneMgr, imlClient)
 	if err != nil {
 		logger.ErrorLogger().Printf("Failed to create AppInstanceFactory: %v", err)
 		panic("Failed to create AppInstanceFactory: " + err.Error())
 	}
-	vnfFactory, err := vnfs.NewInstanceFactory(registry, eb, dataplane, imlClient)
+	vnfFactory, err := vnfs.NewInstanceFactory(registry, eb, dataplaneMgr, imlClient)
 	if err != nil {
 		logger.ErrorLogger().Printf("Failed to create VnfInstanceFactory: %v", err)
 		panic("Failed to create VnfInstanceFactory: " + err.Error())

--- a/go-daemon/main.go
+++ b/go-daemon/main.go
@@ -154,7 +154,7 @@ func main() {
 	}
 
 	// Initialize the route calculation service
-	routeCalcService, err := routecalc.NewRouteCalcService(registry, eb)
+	routeCalcService, err := routecalc.NewInMemoryService(registry, eb)
 	if err != nil {
 		logger.ErrorLogger().Printf("Failed to initialize RouteCalcService: %v", err)
 		panic("Failed to initialize RouteCalcService: " + err.Error())

--- a/go-daemon/mqtt/client.go
+++ b/go-daemon/mqtt/client.go
@@ -15,13 +15,19 @@ import (
 
 type Topic string
 
-type Client struct {
+type Client interface {
+	Add(sub Subscription) (Topic, error)
+	Remove(subscriptionTopic Topic) error
+	RegisterHandler(topic string, handler paho.MessageHandler) error
+}
+
+type ClientImpl struct {
 	conn   *autopaho.ConnectionManager
 	subs   map[Topic]Subscription
 	router paho.Router
 }
 
-func NewClient(ctx context.Context) (*Client, error) {
+func NewClient(ctx context.Context) (Client, error) {
 	u, err := url.Parse(env.MQTT_URL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse MQTT URL: %v", err)
@@ -34,11 +40,10 @@ func NewClient(ctx context.Context) (*Client, error) {
 
 	router := paho.NewStandardRouter()
 
-	client := &Client{
+	client := &ClientImpl{
 		subs:   make(map[Topic]Subscription),
 		router: router,
 	}
-
 
 	clientConfig := autopaho.ClientConfig{
 		ServerUrls: []*url.URL{u},
@@ -66,7 +71,7 @@ func NewClient(ctx context.Context) (*Client, error) {
 	return client, nil
 }
 
-func (c *Client) Add(sub Subscription) (Topic, error) {
+func (c *ClientImpl) Add(sub Subscription) (Topic, error) {
 	topic := sub.Topic()
 	logger.DebugLogger().Printf("Adding MQTT subscription for topic %s", topic)
 	subAck, err := c.conn.Subscribe(context.Background(), &paho.Subscribe{
@@ -82,7 +87,7 @@ func (c *Client) Add(sub Subscription) (Topic, error) {
 	return topic, nil
 }
 
-func (c *Client) Remove(subscriptionTopic Topic) error {
+func (c *ClientImpl) Remove(subscriptionTopic Topic) error {
 	_, ok := c.subs[subscriptionTopic]
 	if !ok {
 		logger.DebugLogger().Printf("No subscription found for topic %s, skipping...", subscriptionTopic)
@@ -99,7 +104,7 @@ func (c *Client) Remove(subscriptionTopic Topic) error {
 	return nil
 }
 
-func (c *Client) RegisterHandler(topic string, handler paho.MessageHandler) error {
+func (c *ClientImpl) RegisterHandler(topic string, handler paho.MessageHandler) error {
 	if handler == nil {
 		return fmt.Errorf("cannot register nil handler for topic %s", topic)
 	}

--- a/go-daemon/mqtt/client.go
+++ b/go-daemon/mqtt/client.go
@@ -28,6 +28,10 @@ type ClientImpl struct {
 }
 
 func NewClient(ctx context.Context) (Client, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context cannot be nil")
+	}
+
 	u, err := url.Parse(env.MQTT_URL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse MQTT URL: %v", err)

--- a/go-daemon/mqtt/mqtt_test.go
+++ b/go-daemon/mqtt/mqtt_test.go
@@ -1,0 +1,17 @@
+package mqtt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMQTTServiceCreationFailsWhenDependenciesAreNil(t *testing.T) {
+	t.Run("Error should be thrown when context is nil", func(t *testing.T) {
+		t.Parallel()
+
+		client, err := NewClient(nil)
+		assert.Nil(t, client)
+		assert.Error(t, err)
+	})
+}

--- a/go-daemon/services/events/eventbus.go
+++ b/go-daemon/services/events/eventbus.go
@@ -1,15 +1,21 @@
 package events
 
-// NewEventBus creates a new EventBus instance.
-func NewEventBus() *EventBus {
-	return &EventBus{
+type EventBus interface {
+	Subscribe(eventName string, handler Handler) uint64
+	Unsubscribe(eventName string, id uint64)
+	Publish(event Event)
+}
+
+// NewInMemory creates a new EventBus instance.
+func NewInMemory() EventBus {
+	return &InMemoryEventBus{
 		subscribers: make(map[string][]subscription),
 		nextID:      1,
 	}
 }
 
 // Subscribe registers a handler for the given event name. It returns a unique subscription ID.
-func (eb *EventBus) Subscribe(eventName string, handler Handler) uint64 {
+func (eb *InMemoryEventBus) Subscribe(eventName string, handler Handler) uint64 {
 	eb.mu.Lock()
 	defer eb.mu.Unlock()
 
@@ -23,7 +29,7 @@ func (eb *EventBus) Subscribe(eventName string, handler Handler) uint64 {
 }
 
 // Unsubscribe removes the subscription for the given event name and subscription ID.
-func (eb *EventBus) Unsubscribe(eventName string, id uint64) {
+func (eb *InMemoryEventBus) Unsubscribe(eventName string, id uint64) {
 	eb.mu.Lock()
 	defer eb.mu.Unlock()
 
@@ -39,7 +45,7 @@ func (eb *EventBus) Unsubscribe(eventName string, id uint64) {
 
 // Publish sends the event to all registered handlers for its name.
 // Each handler is invoked asynchronously in its own goroutine.
-func (eb *EventBus) Publish(event Event) {
+func (eb *InMemoryEventBus) Publish(event Event) {
 	eb.mu.RLock()
 	subs, found := eb.subscribers[event.Name]
 	eb.mu.RUnlock()

--- a/go-daemon/services/events/types.go
+++ b/go-daemon/services/events/types.go
@@ -38,8 +38,8 @@ type subscription struct {
 	handler Handler
 }
 
-// EventBus provides publish/subscribe capabilities for domain events.
-type EventBus struct {
+// InMemoryEventBus provides publish/subscribe capabilities for domain events.
+type InMemoryEventBus struct {
 	subscribers map[string][]subscription // map of event name -> list of subscriptions
 	mu          sync.RWMutex              // protects subscribers
 	nextID      uint64                    // incremental ID generator

--- a/go-daemon/services/iml/client.go
+++ b/go-daemon/services/iml/client.go
@@ -19,14 +19,19 @@ import (
 	"net/http"
 )
 
-type Client struct {
-	eb   *events.EventBus
-	repo *db.Registry
+type Client interface {
+	GetApplication(id string) (*models.Application, error)
+	GetNetworkFunction(id string) (*models.VirtualNetworkFunction, error)
+}
+
+type ClientImpl struct {
+	eb   events.EventBus
+	repo db.Registry
 
 	manager *subscriptions.SubscriptionManager
 }
 
-func NewClient(eb *events.EventBus, repo *db.Registry, manager *subscriptions.SubscriptionManager) (*Client, error) {
+func NewClient(eb events.EventBus, repo db.Registry, manager *subscriptions.SubscriptionManager) (Client, error) {
 	if eb == nil {
 		return nil, fmt.Errorf("event bus is required")
 	}
@@ -37,7 +42,7 @@ func NewClient(eb *events.EventBus, repo *db.Registry, manager *subscriptions.Su
 		return nil, fmt.Errorf("subscription manager is required")
 	}
 
-	client := &Client{
+	client := &ClientImpl{
 		eb:      eb,
 		repo:    repo,
 		manager: manager,
@@ -59,7 +64,7 @@ func NewClient(eb *events.EventBus, repo *db.Registry, manager *subscriptions.Su
 // If you want to keep the application updated, use PullApplication instead.
 //
 // This method is the correct way to check the state of an application.
-func (c *Client) GetApplication(id string) (*models.Application, error) {
+func (c *ClientImpl) GetApplication(id string) (*models.Application, error) {
 	// First, check if the application already exists locally
 	// If the application exists, and it is active, then it means that
 	// it is already synchronized with IML via MQTT, so we can return it directly.
@@ -106,7 +111,7 @@ func (c *Client) GetApplication(id string) (*models.Application, error) {
 	return app, nil
 }
 
-func (c *Client) GetNetworkFunction(id string) (*models.VirtualNetworkFunction, error) {
+func (c *ClientImpl) GetNetworkFunction(id string) (*models.VirtualNetworkFunction, error) {
 	// First, check if the network function already exists locally
 	// If the network function exists, and it is active, then it means that
 	// it is already synchronized with IML via MQTT, so we can return it directly.

--- a/go-daemon/services/iml/controllers/app_def.go
+++ b/go-daemon/services/iml/controllers/app_def.go
@@ -42,7 +42,7 @@ type AppDefinitionController struct {
 	topicRegex *regexp.Regexp
 }
 
-func (c *AppDefinitionController) SetupWithMQTT(client *mqtt.Client) error {
+func (c *AppDefinitionController) SetupWithMQTT(client mqtt.Client) error {
 	c.topics = make(map[ApplicationDefinitionTopic]ApplicationDefinitionTopicData)
 	c.eventQueue = &SliceQueue{}
 	regex, err := regexp.CompilePOSIX(APP_DEFINITION_TOPIC_STR)

--- a/go-daemon/services/iml/controllers/app_def.go
+++ b/go-daemon/services/iml/controllers/app_def.go
@@ -34,7 +34,7 @@ type ApplicationDefinitionTopicData struct {
 }
 
 type AppDefinitionController struct {
-	Registry   *db.Registry
+	Registry   db.Registry
 	SubManager *subscriptions.SubscriptionManager
 
 	topics     map[ApplicationDefinitionTopic]ApplicationDefinitionTopicData

--- a/go-daemon/services/iml/controllers/app_groups.go
+++ b/go-daemon/services/iml/controllers/app_groups.go
@@ -35,7 +35,7 @@ type RemoteAppGroupsTopicData struct {
 }
 
 type AppGroupsController struct {
-	Registry   *db.Registry
+	Registry   db.Registry
 	SubManager *subscriptions.SubscriptionManager
 
 	topics     map[RemoteAppGroupsTopic]RemoteAppGroupsTopicData

--- a/go-daemon/services/iml/controllers/app_groups.go
+++ b/go-daemon/services/iml/controllers/app_groups.go
@@ -43,7 +43,7 @@ type AppGroupsController struct {
 	topicRegex *regexp.Regexp
 }
 
-func (c *AppGroupsController) SetupWithMQTT(client *mqtt.Client) error {
+func (c *AppGroupsController) SetupWithMQTT(client mqtt.Client) error {
 	c.topics = make(map[RemoteAppGroupsTopic]RemoteAppGroupsTopicData)
 	c.eventQueue = &SliceQueue{}
 	regex, err := regexp.CompilePOSIX(APP_INSTANCES_TOPIC_STR)

--- a/go-daemon/services/iml/controllers/app_services.go
+++ b/go-daemon/services/iml/controllers/app_services.go
@@ -32,7 +32,7 @@ type ApplicationServicesTopicData struct {
 }
 
 type AppServicesController struct {
-	Registry   *db.Registry
+	Registry   db.Registry
 	SubManager *subscriptions.SubscriptionManager
 
 	topics     map[ApplicationServicesTopic]ApplicationServicesTopicData

--- a/go-daemon/services/iml/controllers/app_services.go
+++ b/go-daemon/services/iml/controllers/app_services.go
@@ -40,7 +40,7 @@ type AppServicesController struct {
 	topicRegex *regexp.Regexp
 }
 
-func (c *AppServicesController) SetupWithMQTT(client *mqtt.Client) error {
+func (c *AppServicesController) SetupWithMQTT(client mqtt.Client) error {
 	c.topics = make(map[ApplicationServicesTopic]ApplicationServicesTopicData)
 	c.eventQueue = &SliceQueue{}
 	regex, err := regexp.CompilePOSIX(APP_SERVICES_TOPIC_STR)

--- a/go-daemon/services/iml/controllers/interface.go
+++ b/go-daemon/services/iml/controllers/interface.go
@@ -20,12 +20,13 @@ type Result struct {
 	// Valid values are greater than zero.
 	RequeueAfter time.Duration
 }
+
 func (r Result) IsZero() bool {
 	return !(r.RequeueAfter > 0)
 }
 
 type Controller interface {
-	SetupWithIMLClient(*iml.Client) error
+	SetupWithIMLClient(*iml.ClientImpl) error
 	HandleMessage(*paho.Publish) error
 	OnUpdate(Topic, Update) (Result, error)
 	OnDelete(Topic, mqtt.Message) (Result, error)

--- a/go-daemon/services/iml/controllers/node_def.go
+++ b/go-daemon/services/iml/controllers/node_def.go
@@ -33,7 +33,7 @@ type NodeDefinitionTopicData struct {
 }
 
 type NodeDefinitionController struct {
-	Registry   *db.Registry
+	Registry   db.Registry
 	SubManager *subscriptions.SubscriptionManager
 
 	topics     map[NodeDefinitionTopic]NodeDefinitionTopicData

--- a/go-daemon/services/iml/controllers/node_def.go
+++ b/go-daemon/services/iml/controllers/node_def.go
@@ -41,7 +41,7 @@ type NodeDefinitionController struct {
 	topicRegex *regexp.Regexp
 }
 
-func (c *NodeDefinitionController) SetupWithMQTT(client *mqtt.Client) error {
+func (c *NodeDefinitionController) SetupWithMQTT(client mqtt.Client) error {
 	c.topics = make(map[NodeDefinitionTopic]NodeDefinitionTopicData)
 	c.eventQueue = &SliceQueue{}
 	regex, err := regexp.CompilePOSIX(NODE_DEFINITION_TOPIC_STR)

--- a/go-daemon/services/iml/controllers/svc_chains.go
+++ b/go-daemon/services/iml/controllers/svc_chains.go
@@ -34,9 +34,9 @@ type ChainDefinitionTopicData struct {
 }
 
 type ChainDefinitionController struct {
-	Registry   *db.Registry
+	Registry   db.Registry
 	SubManager *subscriptions.SubscriptionManager
-	EventBus   *events.EventBus
+	EventBus   events.EventBus
 
 	topics     map[ChainDefinitionTopic]ChainDefinitionTopicData
 	eventQueue Queue
@@ -269,8 +269,8 @@ func (c *ChainDefinitionController) OnUpdate(topic ChainDefinitionTopic, update 
 			return Result{RequeueAfter: 5 * time.Second}, fmt.Errorf("virtual Network Function ID %s for Service Chain ID %s not found in local database", vnfIdentifier.FunctionUID, topic.ChainID)
 		}
 		vnfs = append(vnfs, models.ServiceChainVnfs{
-			Position: uint8(i),
-			VnfID:    vnfRec.ID,
+			Position:      uint8(i),
+			VnfID:         vnfRec.ID,
 			SubfunctionID: vnfIdentifier.SubFunctionID,
 		})
 	}

--- a/go-daemon/services/iml/controllers/svc_chains.go
+++ b/go-daemon/services/iml/controllers/svc_chains.go
@@ -43,7 +43,7 @@ type ChainDefinitionController struct {
 	topicRegex *regexp.Regexp
 }
 
-func (c *ChainDefinitionController) SetupWithMQTT(client *mqtt.Client) error {
+func (c *ChainDefinitionController) SetupWithMQTT(client mqtt.Client) error {
 	c.topics = make(map[ChainDefinitionTopic]ChainDefinitionTopicData)
 	c.eventQueue = &SliceQueue{}
 	regex, err := regexp.CompilePOSIX(CHAIN_DEFINITION_TOPIC_STR)

--- a/go-daemon/services/iml/controllers/vnf_def.go
+++ b/go-daemon/services/iml/controllers/vnf_def.go
@@ -33,7 +33,7 @@ type VnfDefinitionTopicData struct {
 }
 
 type VNFDefinitionController struct {
-	Registry   *db.Registry
+	Registry   db.Registry
 	SubManager *subscriptions.SubscriptionManager
 
 	topics     map[VnfDefinitionTopic]VnfDefinitionTopicData

--- a/go-daemon/services/iml/controllers/vnf_def.go
+++ b/go-daemon/services/iml/controllers/vnf_def.go
@@ -41,7 +41,7 @@ type VNFDefinitionController struct {
 	topicRegex *regexp.Regexp
 }
 
-func (c *VNFDefinitionController) SetupWithMQTT(client *mqtt.Client) error {
+func (c *VNFDefinitionController) SetupWithMQTT(client mqtt.Client) error {
 	c.topics = make(map[VnfDefinitionTopic]VnfDefinitionTopicData)
 	c.eventQueue = &SliceQueue{}
 	regex, err := regexp.CompilePOSIX(VNF_DEFINITION_TOPIC_STR)

--- a/go-daemon/services/iml/controllers/vnf_groups.go
+++ b/go-daemon/services/iml/controllers/vnf_groups.go
@@ -43,7 +43,7 @@ type VnfGroupsController struct {
 	topicRegex *regexp.Regexp
 }
 
-func (c *VnfGroupsController) SetupWithMQTT(client *mqtt.Client) error {
+func (c *VnfGroupsController) SetupWithMQTT(client mqtt.Client) error {
 	c.topics = make(map[RemoteVnfGroupsTopic]RemoteVnfGroupsTopicData)
 	c.eventQueue = &SliceQueue{}
 	regex, err := regexp.CompilePOSIX(VNF_INSTANCES_TOPIC_STR)

--- a/go-daemon/services/iml/controllers/vnf_groups.go
+++ b/go-daemon/services/iml/controllers/vnf_groups.go
@@ -35,7 +35,7 @@ type RemoteVnfGroupsTopicData struct {
 }
 
 type VnfGroupsController struct {
-	Registry   *db.Registry
+	Registry   db.Registry
 	SubManager *subscriptions.SubscriptionManager
 
 	topics     map[RemoteVnfGroupsTopic]RemoteVnfGroupsTopicData

--- a/go-daemon/services/iml/event_handlers.go
+++ b/go-daemon/services/iml/event_handlers.go
@@ -7,7 +7,7 @@ import (
 	"iml-daemon/services/iml/subscriptions"
 )
 
-func (c *Client) handleLocalAppGroupCreated(event events.Event) {
+func (c *ClientImpl) handleLocalAppGroupCreated(event events.Event) {
 	logger.DebugLogger().Printf("iml.handleLocalAppGroupCreated: %v", event)
 	appGroup, ok := event.Payload.(models.AppGroup)
 	if !ok {
@@ -30,7 +30,7 @@ func (c *Client) handleLocalAppGroupCreated(event events.Event) {
 	}
 }
 
-func (c *Client) handleLocalAppGroupRemoved(event events.Event) {
+func (c *ClientImpl) handleLocalAppGroupRemoved(event events.Event) {
 	logger.DebugLogger().Printf("iml.handleLocalAppGroupRemoved: %v", event)
 	appGroup, ok := event.Payload.(models.AppGroup)
 	if !ok {
@@ -53,7 +53,7 @@ func (c *Client) handleLocalAppGroupRemoved(event events.Event) {
 	}
 }
 
-func (c *Client) handleLocalVnfGroupCreated(event events.Event) {
+func (c *ClientImpl) handleLocalVnfGroupCreated(event events.Event) {
 	logger.DebugLogger().Printf("iml.handleLocalVnfGroupCreated: %v", event)
 	vnfGroup, ok := event.Payload.(models.SimpleVnfGroup)
 	if !ok {
@@ -76,7 +76,7 @@ func (c *Client) handleLocalVnfGroupCreated(event events.Event) {
 	}
 }
 
-func (c *Client) handleLocalVnfMultiplexedGroupCreated(event events.Event) {
+func (c *ClientImpl) handleLocalVnfMultiplexedGroupCreated(event events.Event) {
 	logger.DebugLogger().Printf("iml.handleLocalVnfMultiplexedGroupCreated: %v", event)
 	vnfGroup, ok := event.Payload.(models.MultiplexedVnfGroup)
 	if !ok {
@@ -98,7 +98,7 @@ func (c *Client) handleLocalVnfMultiplexedGroupCreated(event events.Event) {
 	}
 }
 
-func (c *Client) handleLocalVnfGroupRemoved(event events.Event) {
+func (c *ClientImpl) handleLocalVnfGroupRemoved(event events.Event) {
 	logger.DebugLogger().Printf("iml.handleLocalVnfGroupRemoved: %v", event)
 	vnfGroup, ok := event.Payload.(models.SimpleVnfGroup)
 	if !ok {
@@ -121,7 +121,7 @@ func (c *Client) handleLocalVnfGroupRemoved(event events.Event) {
 	}
 }
 
-func (c *Client) handleLocalVnfMultiplexedGroupRemoved(event events.Event) {
+func (c *ClientImpl) handleLocalVnfMultiplexedGroupRemoved(event events.Event) {
 	logger.DebugLogger().Printf("iml.handleLocalVnfMultiplexedGroupRemoved: %v", event)
 	vnfGroup, ok := event.Payload.(models.MultiplexedVnfGroup)
 	if !ok {

--- a/go-daemon/services/iml/subscriptions/manager.go
+++ b/go-daemon/services/iml/subscriptions/manager.go
@@ -12,12 +12,12 @@ type SubscriptionManager struct {
 	subscriptions map[SubscriptionKey]Subscription
 	dependencies  map[DependencyKey]Dependency
 	mqttClient    *mqtt.Client
-	repo          *db.Registry
+	repo          db.Registry
 
 	_mutex sync.RWMutex
 }
 
-func NewSubscriptionManager(mqttClient *mqtt.Client, repo *db.Registry) (*SubscriptionManager, error) {
+func NewSubscriptionManager(mqttClient *mqtt.Client, repo db.Registry) (*SubscriptionManager, error) {
 	if mqttClient == nil {
 		return nil, fmt.Errorf("SubscriptionManager.NewSubscriptionManager: mqttClient is nil")
 	}
@@ -29,7 +29,7 @@ func NewSubscriptionManager(mqttClient *mqtt.Client, repo *db.Registry) (*Subscr
 		subscriptions: make(map[SubscriptionKey]Subscription),
 		dependencies:  make(map[DependencyKey]Dependency),
 		mqttClient:    mqttClient,
-		repo:         repo,
+		repo:          repo,
 	}, nil
 }
 

--- a/go-daemon/services/iml/subscriptions/manager.go
+++ b/go-daemon/services/iml/subscriptions/manager.go
@@ -11,13 +11,13 @@ import (
 type SubscriptionManager struct {
 	subscriptions map[SubscriptionKey]Subscription
 	dependencies  map[DependencyKey]Dependency
-	mqttClient    *mqtt.Client
+	mqttClient    mqtt.Client
 	repo          db.Registry
 
 	_mutex sync.RWMutex
 }
 
-func NewSubscriptionManager(mqttClient *mqtt.Client, repo db.Registry) (*SubscriptionManager, error) {
+func NewSubscriptionManager(mqttClient mqtt.Client, repo db.Registry) (*SubscriptionManager, error) {
 	if mqttClient == nil {
 		return nil, fmt.Errorf("SubscriptionManager.NewSubscriptionManager: mqttClient is nil")
 	}

--- a/go-daemon/services/routecalc/routecalc.go
+++ b/go-daemon/services/routecalc/routecalc.go
@@ -12,16 +12,20 @@ import (
 	"sync"
 )
 
-// RouteCalcService listens for topology events and recalculates routes.
-type RouteCalcService struct {
+// Route Calculation Service listens for topology events and recalculates routes.
+type Service interface {
+	Shutdown(ctx context.Context) error
+}
+
+type InMemoryService struct {
 	eventBus events.EventBus
 	registry db.Registry
 	graph    *Graph
 	mutex    sync.Mutex
 }
 
-// NewRouteCalcService constructs the service and subscribes to events.
-func NewRouteCalcService(registry db.Registry, eb events.EventBus) (*RouteCalcService, error) {
+// NewInMemoryService constructs the service and subscribes to events.
+func NewInMemoryService(registry db.Registry, eb events.EventBus) (Service, error) {
 	// Validate the event bus and registry
 	if eb == nil {
 		return nil, fmt.Errorf("event bus cannot be nil")
@@ -34,7 +38,7 @@ func NewRouteCalcService(registry db.Registry, eb events.EventBus) (*RouteCalcSe
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new graph: %w", err)
 	}
-	rc := &RouteCalcService{
+	rc := &InMemoryService{
 		eventBus: eb,
 		registry: registry,
 		graph:    g,
@@ -62,7 +66,7 @@ func NewRouteCalcService(registry db.Registry, eb events.EventBus) (*RouteCalcSe
 }
 
 // handleEvent processes incoming events and triggers recalculation.
-func (rc *RouteCalcService) handleEvent(evt events.Event) {
+func (rc *InMemoryService) handleEvent(evt events.Event) {
 	logger.InfoLogger().Printf("RouteCalcService received event: %s", evt.Name)
 	defer func() {
 		if r := recover(); r != nil {
@@ -198,7 +202,7 @@ func (rc *RouteCalcService) handleEvent(evt events.Event) {
 }
 
 // recalculateAll retrieves all chains and recomputes their routes.
-func (rc *RouteCalcService) recalculateAll() error {
+func (rc *InMemoryService) recalculateAll() error {
 	// Get all network service chains
 	chains, err := rc.registry.FindAllNetworkServiceChains()
 	if err != nil {
@@ -237,7 +241,7 @@ func (rc *RouteCalcService) recalculateAll() error {
 }
 
 // computeRoute finds shortest path for a single chain.
-func (rc *RouteCalcService) computeRoutes(chain *models.ServiceChain) ([]*Route, error) {
+func (rc *InMemoryService) computeRoutes(chain *models.ServiceChain) ([]*Route, error) {
 
 	srcAppNode := rc.graph.FindLocalAppGroupNode(chain.SrcAppID)
 	if srcAppNode == nil {
@@ -293,7 +297,7 @@ func (rc *RouteCalcService) computeRoutes(chain *models.ServiceChain) ([]*Route,
 	return routes, nil
 }
 
-func (rc *RouteCalcService) Shutdown(ctx context.Context) error {
+func (rc *InMemoryService) Shutdown(ctx context.Context) error {
 	// Place any necessary cleanup logic here
 	// Maybe cancel any ongoing calculations or close resources
 	// For now, this is a no-op

--- a/go-daemon/services/routecalc/routecalc.go
+++ b/go-daemon/services/routecalc/routecalc.go
@@ -14,14 +14,14 @@ import (
 
 // RouteCalcService listens for topology events and recalculates routes.
 type RouteCalcService struct {
-	eventBus *events.EventBus
-	registry *db.Registry
+	eventBus events.EventBus
+	registry db.Registry
 	graph    *Graph
 	mutex    sync.Mutex
 }
 
 // NewRouteCalcService constructs the service and subscribes to events.
-func NewRouteCalcService(registry *db.Registry, eb *events.EventBus) (*RouteCalcService, error) {
+func NewRouteCalcService(registry db.Registry, eb events.EventBus) (*RouteCalcService, error) {
 	// Validate the event bus and registry
 	if eb == nil {
 		return nil, fmt.Errorf("event bus cannot be nil")

--- a/go-daemon/services/router/dataplane/alloc.go
+++ b/go-daemon/services/router/dataplane/alloc.go
@@ -1,4 +1,4 @@
-package router
+package dataplane
 
 import (
 	"fmt"

--- a/go-daemon/services/router/dataplane/manager.go
+++ b/go-daemon/services/router/dataplane/manager.go
@@ -1,0 +1,39 @@
+package dataplane
+
+import (
+	"net"
+
+	"github.com/google/uuid"
+)
+
+type VNFSubnet interface {
+	Network()   *net.IPNet
+	GatewayIP() net.IP
+	SIDs()      []net.IPNet
+	Bridge()    string
+}
+
+type AppSubnet interface {
+	Network()   *net.IPNet
+	GatewayIP() net.IP
+	Bridge()    string
+}
+
+type Manager interface {
+	Close() error
+
+	AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (VNFSubnet, error)
+	AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error)
+
+	RemoveApplicationSubnet(appGroupID uuid.UUID)
+	RemoveVNFSubnet(vnfGroupID uuid.UUID)
+
+	AddApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) (*net.IPNet, string, error)
+	RemoveApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) error
+	
+	AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) (*net.IPNet, string, error)
+	RemoveVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) error
+
+	AddRoute(srcAppGroup uuid.UUID, dstNet net.IPNet, sids []net.IP) error
+	RemoveRoute(srcAppGroup uuid.UUID, dstNet string) error
+}

--- a/go-daemon/services/router/dataplane/software_linux.go
+++ b/go-daemon/services/router/dataplane/software_linux.go
@@ -16,17 +16,17 @@ import (
 )
 
 type Software struct {
-	appSubnets      map[uuid.UUID]*appSubnet
-	appMu						sync.Mutex
-	vnfSubnets      map[uuid.UUID]*vnfSubnet
-	vnfMu						sync.Mutex
-	routerVrf			  *netlink.Vrf
+	appSubnets map[uuid.UUID]*appSubnet
+	appMu      sync.Mutex
+	vnfSubnets map[uuid.UUID]*vnfSubnet
+	vnfMu      sync.Mutex
+	routerVrf  *netlink.Vrf
 
 	appNetAllocator *Subnet6Allocator
 	vnfNetAllocator *Subnet6Allocator
 	sidNetAllocator *Subnet6Allocator
 	tunNetAllocator *Subnet6Allocator
-	tableAllocator	*TableAllocator
+	tableAllocator  *TableAllocator
 }
 
 type appSubnet struct {
@@ -35,9 +35,10 @@ type appSubnet struct {
 	bridge        *netlink.Bridge
 	VethBridgeVRF *netlink.Veth
 	Vrf           *netlink.Vrf
-	Tunnel			  *netlink.Veth
+	Tunnel        *netlink.Veth
 	IPAllocator   *IPv6Allocator
 }
+
 func (as *appSubnet) Network() *net.IPNet {
 	return as.network
 }
@@ -58,6 +59,7 @@ type vnfSubnet struct {
 	Instances     map[uuid.UUID]net.IP
 	mu            sync.Mutex
 }
+
 func (vs *vnfSubnet) Network() *net.IPNet {
 	return vs.network
 }
@@ -71,7 +73,7 @@ func (vs *vnfSubnet) Bridge() string {
 	return vs.bridge.Attrs().Name
 }
 
-func NewSoftware(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet, tunRange *net.IPNet) (*Software, error) {
+func NewSoftware(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet, tunRange *net.IPNet) (Manager, error) {
 	// Enable IPv6 forwarding. Required in host namespace to route packets between interfaces.
 	if err := os.WriteFile("/proc/sys/net/ipv6/conf/all/forwarding", []byte("1"), 0644); err != nil {
 		return nil, fmt.Errorf("failed to enable IPv6 forwarding: %w", err)
@@ -111,7 +113,7 @@ func NewSoftware(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet, 
 		appNetAllocator: appNetAllocator,
 		vnfNetAllocator: vnfNetAllocator,
 		tunNetAllocator: tunNetAllocator,
-		tableAllocator:	 tableAllocator,
+		tableAllocator:  tableAllocator,
 		appSubnets:      make(map[uuid.UUID]*appSubnet),
 		vnfSubnets:      make(map[uuid.UUID]*vnfSubnet),
 	}
@@ -154,9 +156,9 @@ func (d *Software) AddRoute(srcAppGroup uuid.UUID, dstNet net.IPNet, sids []net.
 
 	// ip route add <dstNet> vrf <subnet.Vrf> encap seg6 mode encap segs <sids> dev <subnet.tunnel>
 	route := &netlink.Route{
-		Dst:        &dstNet,
-		Table:      int(subnet.Vrf.Table),
-		Encap:      &netlink.SEG6Encap{
+		Dst:   &dstNet,
+		Table: int(subnet.Vrf.Table),
+		Encap: &netlink.SEG6Encap{
 			Mode:     nl.SEG6_IPTUN_MODE_ENCAP,
 			Segments: sids,
 		},
@@ -195,7 +197,7 @@ func (d *Software) RemoveRoute(srcAppGroup uuid.UUID, dstNet string) error {
 	return nil
 }
 
-// Creates a subnet into the dataplane and returns the configured bridge name. 
+// Creates a subnet into the dataplane and returns the configured bridge name.
 func (d *Software) AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error) {
 	d.appMu.Lock()
 	defer d.appMu.Unlock()
@@ -328,11 +330,11 @@ func (d *Software) AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error)
 		return nil, fmt.Errorf("failed to get link-local address for app tunnel in application subnet: %w", err)
 	}
 
-	// Create a route in the router VRF to reach the application subnet using 
+	// Create a route in the router VRF to reach the application subnet using
 	// the app tunnel as the outgoing interface.
 	routeToApp := &netlink.Route{
 		Dst:       AppNetwork,
-		Gw: 			 rtTunLLAddr.IP,
+		Gw:        rtTunLLAddr.IP,
 		Table:     int(d.routerVrf.Table),
 		LinkIndex: appTunnel.Attrs().Index,
 	}
@@ -345,7 +347,7 @@ func (d *Software) AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error)
 	// Create a route in the application VRF to reach the router subnet using
 	// the router tunnel as the outgoing interface.
 	routeToRouter := &netlink.Route{
-		Dst:       &net.IPNet{
+		Dst: &net.IPNet{
 			IP:   net.ParseIP("::"),
 			Mask: net.CIDRMask(0, 128),
 		},
@@ -373,7 +375,7 @@ func (d *Software) AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error)
 			Name:        bridgeName,
 			MasterIndex: appVrf.Attrs().Index,
 		},
-	}	
+	}
 	if err := netlink.LinkAdd(bridge); err != nil {
 		d.cleanupAppSubnet(subnet)
 		return nil, fmt.Errorf("failed to add bridge %s: %w", bridgeName, err)
@@ -386,7 +388,7 @@ func (d *Software) AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error)
 
 	vethFromBridgeToVrf := &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{
-			Name: fmt.Sprintf("%s-%d", hexStr, appVrf.Table),
+			Name:        fmt.Sprintf("%s-%d", hexStr, appVrf.Table),
 			MasterIndex: bridge.Attrs().Index,
 		},
 		PeerName: fmt.Sprintf("%d-%s", appVrf.Table, hexStr),
@@ -428,7 +430,9 @@ func (d *Software) RemoveApplicationSubnet(appGroupID uuid.UUID) {
 	defer d.appMu.Unlock()
 
 	subnet, exists := d.appSubnets[appGroupID]
-	if !exists { return }
+	if !exists {
+		return
+	}
 	d.cleanupAppSubnet(subnet)
 	delete(d.appSubnets, appGroupID)
 }
@@ -508,9 +512,9 @@ func (d *Software) AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (VNFSubnet,
 
 	bridge := &netlink.Bridge{
 		LinkAttrs: netlink.LinkAttrs{
-			Name:        bridgeName,
+			Name: bridgeName,
 		},
-	}	
+	}
 	if err := netlink.LinkAdd(bridge); err != nil {
 		return nil, fmt.Errorf("failed to add bridge %s: %w", bridgeName, err)
 	}
@@ -522,7 +526,7 @@ func (d *Software) AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (VNFSubnet,
 
 	vethFromBridgeToVrf := &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{
-			Name: fmt.Sprintf("%s-%d", hexStr, d.routerVrf.Table),
+			Name:        fmt.Sprintf("%s-%d", hexStr, d.routerVrf.Table),
 			MasterIndex: bridge.Attrs().Index,
 		},
 		PeerName: fmt.Sprintf("%d-%s", d.routerVrf.Table, hexStr),
@@ -565,7 +569,9 @@ func (d *Software) RemoveVNFSubnet(vnfGroupID uuid.UUID) {
 	defer d.vnfMu.Unlock()
 
 	subnet, exists := d.vnfSubnets[vnfGroupID]
-	if !exists { return }
+	if !exists {
+		return
+	}
 	d.cleanupVNFSubnet(subnet)
 	delete(d.vnfSubnets, vnfGroupID)
 }
@@ -576,7 +582,7 @@ func (d *Software) AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID)
 
 	subnet, exists := d.vnfSubnets[vnfGroupID]
 	if !exists {
-		return nil, "",fmt.Errorf("VNF subnet for group %s does not exist", vnfGroupID)
+		return nil, "", fmt.Errorf("VNF subnet for group %s does not exist", vnfGroupID)
 	}
 	subnet.mu.Lock()
 	defer subnet.mu.Unlock()
@@ -598,7 +604,7 @@ func (d *Software) AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID)
 		return nil, "", fmt.Errorf("failed to regenerate vnf subnet next hops: %w", err)
 	}
 	logger.DebugLogger().Printf("VNF subnet %s next hops after adding instance %s: %v", subnet.network.String(), vnfInstanceID, nextHops)
-	
+
 	for _, sid := range subnet.sids {
 		err = d.updateVNFSubnetSIDRoute(&sid, nextHops)
 		if err != nil {
@@ -709,7 +715,7 @@ func (d *Software) cleanupVNFSubnet(subnet *vnfSubnet) {
 }
 
 func (*Software) regenerateVNFSubnetNextHops(subnet *vnfSubnet) ([]*netlink.NexthopInfo, error) {
-	link, err := netlink.LinkByName(subnet.VethBridgeVRF.PeerName);
+	link, err := netlink.LinkByName(subnet.VethBridgeVRF.PeerName)
 	if err != nil {
 		logger.ErrorLogger().Printf("failed to get veth %s: %v", subnet.VethBridgeVRF.Attrs().Name, err)
 		return nil, err
@@ -805,12 +811,12 @@ func (d *Software) setUpRouterSubnet() error {
 	flags_end_dt6_encaps[nl.SEG6_LOCAL_ACTION] = true
 	flags_end_dt6_encaps[nl.SEG6_LOCAL_TABLE] = true
 	decapRoute := &netlink.Route{
-		Dst:       decapSid,
-		Table: 	int(routerVrf.Table),
+		Dst:   decapSid,
+		Table: int(routerVrf.Table),
 		Encap: &netlink.SEG6LocalEncap{
-			Flags:     flags_end_dt6_encaps,
+			Flags:  flags_end_dt6_encaps,
 			Action: nl.SEG6_LOCAL_ACTION_END_DT6,
-			Table: int(routerVrf.Table),
+			Table:  int(routerVrf.Table),
 		},
 		LinkIndex: decapIface.Attrs().Index,
 	}

--- a/go-daemon/services/router/dataplane/software_linux.go
+++ b/go-daemon/services/router/dataplane/software_linux.go
@@ -1,4 +1,4 @@
-package router
+package dataplane
 
 import (
 	"crypto/rand"
@@ -15,10 +15,10 @@ import (
 	"github.com/vishvananda/netlink/nl"
 )
 
-type Dataplane struct {
-	AppSubnets      map[uuid.UUID]*AppSubnet
+type Software struct {
+	appSubnets      map[uuid.UUID]*appSubnet
 	appMu						sync.Mutex
-	VNFSubnets      map[uuid.UUID]*VNFSubnet
+	vnfSubnets      map[uuid.UUID]*vnfSubnet
 	vnfMu						sync.Mutex
 	routerVrf			  *netlink.Vrf
 
@@ -29,28 +29,49 @@ type Dataplane struct {
 	tableAllocator	*TableAllocator
 }
 
-type AppSubnet struct {
-	Network       *net.IPNet
-	GatewayIP     net.IP
-	Bridge        *netlink.Bridge
+type appSubnet struct {
+	network       *net.IPNet
+	gatewayIP     net.IP
+	bridge        *netlink.Bridge
 	VethBridgeVRF *netlink.Veth
 	Vrf           *netlink.Vrf
 	Tunnel			  *netlink.Veth
 	IPAllocator   *IPv6Allocator
 }
+func (as *appSubnet) Network() *net.IPNet {
+	return as.network
+}
+func (as *appSubnet) GatewayIP() net.IP {
+	return as.gatewayIP
+}
+func (as *appSubnet) Bridge() string {
+	return as.bridge.Attrs().Name
+}
 
-type VNFSubnet struct {
-	Network       *net.IPNet
-	GatewayIP     net.IP
-	SIDs          []net.IPNet
-	Bridge        *netlink.Bridge
+type vnfSubnet struct {
+	network       *net.IPNet
+	gatewayIP     net.IP
+	sids          []net.IPNet
+	bridge        *netlink.Bridge
 	VethBridgeVRF *netlink.Veth
 	IPAllocator   *IPv6Allocator
 	Instances     map[uuid.UUID]net.IP
 	mu            sync.Mutex
 }
+func (vs *vnfSubnet) Network() *net.IPNet {
+	return vs.network
+}
+func (vs *vnfSubnet) GatewayIP() net.IP {
+	return vs.gatewayIP
+}
+func (vs *vnfSubnet) SIDs() []net.IPNet {
+	return vs.sids
+}
+func (vs *vnfSubnet) Bridge() string {
+	return vs.bridge.Attrs().Name
+}
 
-func NewDataplane(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet, tunRange *net.IPNet) (*Dataplane, error) {
+func NewSoftware(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet, tunRange *net.IPNet) (*Software, error) {
 	// Enable IPv6 forwarding. Required in host namespace to route packets between interfaces.
 	if err := os.WriteFile("/proc/sys/net/ipv6/conf/all/forwarding", []byte("1"), 0644); err != nil {
 		return nil, fmt.Errorf("failed to enable IPv6 forwarding: %w", err)
@@ -85,14 +106,14 @@ func NewDataplane(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet,
 		return nil, fmt.Errorf("failed to create table allocator: %w", err)
 	}
 
-	dataplane := &Dataplane{
+	dataplane := &Software{
 		sidNetAllocator: sidNetAllocator,
 		appNetAllocator: appNetAllocator,
 		vnfNetAllocator: vnfNetAllocator,
 		tunNetAllocator: tunNetAllocator,
 		tableAllocator:	 tableAllocator,
-		AppSubnets:      make(map[uuid.UUID]*AppSubnet),
-		VNFSubnets:      make(map[uuid.UUID]*VNFSubnet),
+		appSubnets:      make(map[uuid.UUID]*appSubnet),
+		vnfSubnets:      make(map[uuid.UUID]*vnfSubnet),
 	}
 	err = dataplane.setUpRouterSubnet()
 	if err != nil {
@@ -103,30 +124,30 @@ func NewDataplane(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet,
 	return dataplane, nil
 }
 
-func (d *Dataplane) Close() error {
+func (d *Software) Close() error {
 	// Delete the router subnet
 	d.tearDownRouterSubnet()
 
 	// Delete all application and VNF subnets
 	d.appMu.Lock()
 	defer d.appMu.Unlock()
-	for _, subnet := range d.AppSubnets {
+	for _, subnet := range d.appSubnets {
 		d.cleanupAppSubnet(subnet)
 	}
 
 	d.vnfMu.Lock()
 	defer d.vnfMu.Unlock()
-	for _, subnet := range d.VNFSubnets {
+	for _, subnet := range d.vnfSubnets {
 		d.cleanupVNFSubnet(subnet)
 	}
 	return nil
 }
 
-func (d *Dataplane) AddRoute(srcAppGroup uuid.UUID, dstNet net.IPNet, sids []net.IP) error {
+func (d *Software) AddRoute(srcAppGroup uuid.UUID, dstNet net.IPNet, sids []net.IP) error {
 	d.appMu.Lock()
 	defer d.appMu.Unlock()
 
-	subnet, exists := d.AppSubnets[srcAppGroup]
+	subnet, exists := d.appSubnets[srcAppGroup]
 	if !exists {
 		return fmt.Errorf("application subnet for group %s does not exist", srcAppGroup)
 	}
@@ -149,11 +170,11 @@ func (d *Dataplane) AddRoute(srcAppGroup uuid.UUID, dstNet net.IPNet, sids []net
 	return nil
 }
 
-func (d *Dataplane) RemoveRoute(srcAppGroup uuid.UUID, dstNet string) error {
+func (d *Software) RemoveRoute(srcAppGroup uuid.UUID, dstNet string) error {
 	d.appMu.Lock()
 	defer d.appMu.Unlock()
 
-	subnet, exists := d.AppSubnets[srcAppGroup]
+	subnet, exists := d.appSubnets[srcAppGroup]
 	if !exists {
 		return fmt.Errorf("application subnet for group %s does not exist", srcAppGroup)
 	}
@@ -175,21 +196,21 @@ func (d *Dataplane) RemoveRoute(srcAppGroup uuid.UUID, dstNet string) error {
 }
 
 // Creates a subnet into the dataplane and returns the configured bridge name. 
-func (d *Dataplane) AddApplicationSubnet(appGroupID uuid.UUID) (*AppSubnet, error) {
+func (d *Software) AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error) {
 	d.appMu.Lock()
 	defer d.appMu.Unlock()
 
-	_, exists := d.AppSubnets[appGroupID]
+	_, exists := d.appSubnets[appGroupID]
 	if exists {
 		return nil, fmt.Errorf("subnet for app group %s already exists", appGroupID)
 	}
-	subnet := &AppSubnet{}
+	subnet := &appSubnet{}
 
 	AppNetwork, err := d.appNetAllocator.Allocate()
 	if err != nil {
 		return nil, fmt.Errorf("failed to allocate application subnet: %w", err)
 	}
-	subnet.Network = AppNetwork
+	subnet.network = AppNetwork
 
 	ipAllocator, err := NewIPv6Allocator(AppNetwork)
 	if err != nil {
@@ -201,7 +222,7 @@ func (d *Dataplane) AddApplicationSubnet(appGroupID uuid.UUID) (*AppSubnet, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to allocate gateway IP for application subnet: %w", err)
 	}
-	subnet.GatewayIP = gatewayIPNet.IP
+	subnet.gatewayIP = gatewayIPNet.IP
 
 	tableID, err := d.tableAllocator.Allocate()
 	if err != nil {
@@ -357,7 +378,7 @@ func (d *Dataplane) AddApplicationSubnet(appGroupID uuid.UUID) (*AppSubnet, erro
 		d.cleanupAppSubnet(subnet)
 		return nil, fmt.Errorf("failed to add bridge %s: %w", bridgeName, err)
 	}
-	subnet.Bridge = bridge
+	subnet.bridge = bridge
 	if err := netlink.LinkSetUp(bridge); err != nil {
 		d.cleanupAppSubnet(subnet)
 		return nil, fmt.Errorf("failed to set up bridge %s: %w", bridgeName, err)
@@ -398,25 +419,25 @@ func (d *Dataplane) AddApplicationSubnet(appGroupID uuid.UUID) (*AppSubnet, erro
 		return nil, fmt.Errorf("failed to set up veth from vrf to bridge %s: %w", vethFromBridgeToVrf.PeerName, err)
 	}
 
-	d.AppSubnets[appGroupID] = subnet
+	d.appSubnets[appGroupID] = subnet
 	return subnet, nil
 }
 
-func (d *Dataplane) RemoveApplicationSubnet(appGroupID uuid.UUID) {
+func (d *Software) RemoveApplicationSubnet(appGroupID uuid.UUID) {
 	d.appMu.Lock()
 	defer d.appMu.Unlock()
 
-	subnet, exists := d.AppSubnets[appGroupID]
+	subnet, exists := d.appSubnets[appGroupID]
 	if !exists { return }
 	d.cleanupAppSubnet(subnet)
-	delete(d.AppSubnets, appGroupID)
+	delete(d.appSubnets, appGroupID)
 }
 
-func (d *Dataplane) AddApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) (*net.IPNet, string, error) {
+func (d *Software) AddApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) (*net.IPNet, string, error) {
 	d.appMu.Lock()
 	defer d.appMu.Unlock()
 
-	subnet, exists := d.AppSubnets[appGroupID]
+	subnet, exists := d.appSubnets[appGroupID]
 	if !exists {
 		return nil, "", fmt.Errorf("application subnet for group %s does not exist", appGroupID)
 	}
@@ -434,26 +455,26 @@ func (d *Dataplane) AddApplicationInstance(appGroupID uuid.UUID, appInstanceID u
 	return instanceIPNet, ifaceName, nil
 }
 
-func (d *Dataplane) RemoveApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) error {
+func (d *Software) RemoveApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) error {
 	// Nothing to do here for now
 	return nil
 }
 
-func (d *Dataplane) AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (*VNFSubnet, error) {
+func (d *Software) AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (VNFSubnet, error) {
 	d.vnfMu.Lock()
 	defer d.vnfMu.Unlock()
 
-	_, exists := d.VNFSubnets[vnfGroupID]
+	_, exists := d.vnfSubnets[vnfGroupID]
 	if exists {
 		return nil, fmt.Errorf("subnet for VNF group %s already exists", vnfGroupID)
 	}
-	subnet := &VNFSubnet{}
+	subnet := &vnfSubnet{}
 
 	vnfNetwork, err := d.vnfNetAllocator.Allocate()
 	if err != nil {
 		return nil, fmt.Errorf("failed to allocate VNF subnet: %w", err)
 	}
-	subnet.Network = vnfNetwork
+	subnet.network = vnfNetwork
 
 	ipAllocator, err := NewIPv6Allocator(vnfNetwork)
 	if err != nil {
@@ -465,7 +486,7 @@ func (d *Dataplane) AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (*VNFSubne
 	if err != nil {
 		return nil, fmt.Errorf("failed to allocate gateway IP for VNF subnet: %w", err)
 	}
-	subnet.GatewayIP = gatewayIPNet.IP
+	subnet.gatewayIP = gatewayIPNet.IP
 
 	sids := make([]net.IPNet, sidAmount)
 	for i := 0; i < sidAmount; i++ {
@@ -475,7 +496,7 @@ func (d *Dataplane) AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (*VNFSubne
 		}
 		sids[i] = *sidNet
 	}
-	subnet.SIDs = sids
+	subnet.sids = sids
 
 	// Create a bridge in the router vrf
 	b := make([]byte, 4)
@@ -493,7 +514,7 @@ func (d *Dataplane) AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (*VNFSubne
 	if err := netlink.LinkAdd(bridge); err != nil {
 		return nil, fmt.Errorf("failed to add bridge %s: %w", bridgeName, err)
 	}
-	subnet.Bridge = bridge
+	subnet.bridge = bridge
 	if err := netlink.LinkSetUp(bridge); err != nil {
 		d.cleanupVNFSubnet(subnet)
 		return nil, fmt.Errorf("failed to set up bridge %s: %w", bridgeName, err)
@@ -535,25 +556,25 @@ func (d *Dataplane) AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (*VNFSubne
 	}
 
 	subnet.Instances = make(map[uuid.UUID]net.IP)
-	d.VNFSubnets[vnfGroupID] = subnet
+	d.vnfSubnets[vnfGroupID] = subnet
 	return subnet, nil
 }
 
-func (d *Dataplane) RemoveVNFSubnet(vnfGroupID uuid.UUID) {
+func (d *Software) RemoveVNFSubnet(vnfGroupID uuid.UUID) {
 	d.vnfMu.Lock()
 	defer d.vnfMu.Unlock()
 
-	subnet, exists := d.VNFSubnets[vnfGroupID]
+	subnet, exists := d.vnfSubnets[vnfGroupID]
 	if !exists { return }
 	d.cleanupVNFSubnet(subnet)
-	delete(d.VNFSubnets, vnfGroupID)
+	delete(d.vnfSubnets, vnfGroupID)
 }
 
-func (d *Dataplane) AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) (*net.IPNet, string, error) {
+func (d *Software) AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) (*net.IPNet, string, error) {
 	d.vnfMu.Lock()
 	defer d.vnfMu.Unlock()
 
-	subnet, exists := d.VNFSubnets[vnfGroupID]
+	subnet, exists := d.vnfSubnets[vnfGroupID]
 	if !exists {
 		return nil, "",fmt.Errorf("VNF subnet for group %s does not exist", vnfGroupID)
 	}
@@ -576,9 +597,9 @@ func (d *Dataplane) AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to regenerate vnf subnet next hops: %w", err)
 	}
-	logger.DebugLogger().Printf("VNF subnet %s next hops after adding instance %s: %v", subnet.Network.String(), vnfInstanceID, nextHops)
+	logger.DebugLogger().Printf("VNF subnet %s next hops after adding instance %s: %v", subnet.network.String(), vnfInstanceID, nextHops)
 	
-	for _, sid := range subnet.SIDs {
+	for _, sid := range subnet.sids {
 		err = d.updateVNFSubnetSIDRoute(&sid, nextHops)
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to update vnf subnet routes: %w", err)
@@ -587,11 +608,11 @@ func (d *Dataplane) AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID
 	return vnfIPNet, ifaceName, nil
 }
 
-func (d *Dataplane) RemoveVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) error {
+func (d *Software) RemoveVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) error {
 	d.vnfMu.Lock()
 	defer d.vnfMu.Unlock()
 
-	subnet, exists := d.VNFSubnets[vnfGroupID]
+	subnet, exists := d.vnfSubnets[vnfGroupID]
 	if !exists {
 		return fmt.Errorf("VNF subnet for group %s does not exist", vnfGroupID)
 	}
@@ -602,7 +623,7 @@ func (d *Dataplane) RemoveVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.U
 	if err != nil {
 		return fmt.Errorf("failed to regenerate vnf subnet next hops: %w", err)
 	}
-	for _, sid := range subnet.SIDs {
+	for _, sid := range subnet.sids {
 		err = d.updateVNFSubnetSIDRoute(&sid, nextHops)
 		if err != nil {
 			return fmt.Errorf("failed to update vnf subnet routes: %w", err)
@@ -611,7 +632,7 @@ func (d *Dataplane) RemoveVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.U
 	return nil
 }
 
-func (d *Dataplane) createLinkLocalAddrFromMAC(mac net.HardwareAddr) (*net.IPNet, error) {
+func (d *Software) createLinkLocalAddrFromMAC(mac net.HardwareAddr) (*net.IPNet, error) {
 	var eui64 []byte
 	switch len(mac) {
 	case 6:
@@ -651,15 +672,15 @@ func (d *Dataplane) createLinkLocalAddrFromMAC(mac net.HardwareAddr) (*net.IPNet
 	}, nil
 }
 
-func (d *Dataplane) cleanupAppSubnet(subnet *AppSubnet) {
+func (d *Software) cleanupAppSubnet(subnet *appSubnet) {
 	if subnet.VethBridgeVRF != nil {
 		if err := netlink.LinkDel(subnet.VethBridgeVRF); err != nil {
 			logger.ErrorLogger().Printf("failed to delete veth %s: %v", subnet.VethBridgeVRF.Attrs().Name, err)
 		}
 	}
-	if subnet.Bridge != nil {
-		if err := netlink.LinkDel(subnet.Bridge); err != nil {
-			logger.ErrorLogger().Printf("failed to delete bridge %s: %v", subnet.Bridge.Attrs().Name, err)
+	if subnet.bridge != nil {
+		if err := netlink.LinkDel(subnet.bridge); err != nil {
+			logger.ErrorLogger().Printf("failed to delete bridge %s: %v", subnet.bridge.Attrs().Name, err)
 		}
 	}
 	if subnet.Tunnel != nil {
@@ -674,20 +695,20 @@ func (d *Dataplane) cleanupAppSubnet(subnet *AppSubnet) {
 	}
 }
 
-func (d *Dataplane) cleanupVNFSubnet(subnet *VNFSubnet) {
+func (d *Software) cleanupVNFSubnet(subnet *vnfSubnet) {
 	if subnet.VethBridgeVRF != nil {
 		if err := netlink.LinkDel(subnet.VethBridgeVRF); err != nil {
 			logger.ErrorLogger().Printf("failed to delete veth %s: %v", subnet.VethBridgeVRF.Attrs().Name, err)
 		}
 	}
-	if subnet.Bridge != nil {
-		if err := netlink.LinkDel(subnet.Bridge); err != nil {
-			logger.ErrorLogger().Printf("failed to delete bridge %s: %v", subnet.Bridge.Attrs().Name, err)
+	if subnet.bridge != nil {
+		if err := netlink.LinkDel(subnet.bridge); err != nil {
+			logger.ErrorLogger().Printf("failed to delete bridge %s: %v", subnet.bridge.Attrs().Name, err)
 		}
 	}
 }
 
-func (*Dataplane) regenerateVNFSubnetNextHops(subnet *VNFSubnet) ([]*netlink.NexthopInfo, error) {
+func (*Software) regenerateVNFSubnetNextHops(subnet *vnfSubnet) ([]*netlink.NexthopInfo, error) {
 	link, err := netlink.LinkByName(subnet.VethBridgeVRF.PeerName);
 	if err != nil {
 		logger.ErrorLogger().Printf("failed to get veth %s: %v", subnet.VethBridgeVRF.Attrs().Name, err)
@@ -704,7 +725,7 @@ func (*Dataplane) regenerateVNFSubnetNextHops(subnet *VNFSubnet) ([]*netlink.Nex
 	return nextHops, nil
 }
 
-func (d *Dataplane) updateVNFSubnetSIDRoute(sid *net.IPNet, nextHops []*netlink.NexthopInfo) error {
+func (d *Software) updateVNFSubnetSIDRoute(sid *net.IPNet, nextHops []*netlink.NexthopInfo) error {
 	var route *netlink.Route
 	routes, err := netlink.RouteListFiltered(nl.FAMILY_V6, &netlink.Route{
 		Dst:   sid,
@@ -737,7 +758,7 @@ func (d *Dataplane) updateVNFSubnetSIDRoute(sid *net.IPNet, nextHops []*netlink.
 	return nil
 }
 
-func (d *Dataplane) setUpRouterSubnet() error {
+func (d *Software) setUpRouterSubnet() error {
 	routerVrfTable, err := d.tableAllocator.Allocate()
 	if err != nil {
 		return fmt.Errorf("failed to allocate router VRF table ID: %w", err)
@@ -807,7 +828,7 @@ func (d *Dataplane) setUpRouterSubnet() error {
 	return nil
 }
 
-func (d *Dataplane) tearDownRouterSubnet() {
+func (d *Software) tearDownRouterSubnet() {
 	routerVrf, err := netlink.LinkByName("router-vrf")
 	if err == nil {
 		netlink.LinkDel(routerVrf)

--- a/go-daemon/services/router/dataplane/software_stub.go
+++ b/go-daemon/services/router/dataplane/software_stub.go
@@ -1,0 +1,52 @@
+// helper_stub.go
+//go:build !linux && !windows
+
+package dataplane
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/google/uuid"
+)
+
+type Software struct {
+}
+func (s *Software) Close() error {
+	return fmt.Errorf("unsupported architecture")
+}
+
+func (s *Software)	AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (VNFSubnet, error) {
+	return nil, fmt.Errorf("unsupported architecture")
+}
+func (s *Software)	AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error) {
+	return nil, fmt.Errorf("unsupported architecture")
+}
+
+func (s *Software)	RemoveApplicationSubnet(appGroupID uuid.UUID) {}
+func (s *Software)	RemoveVNFSubnet(vnfGroupID uuid.UUID) {}
+
+func (s *Software)	AddApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) (*net.IPNet, string, error) {
+	return nil, "", fmt.Errorf("unsupported architecture")
+}
+func (s *Software)	RemoveApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) error {
+	return fmt.Errorf("unsupported architecture")
+}
+	
+func (s *Software)	AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) (*net.IPNet, string, error) {
+	return nil, "", fmt.Errorf("unsupported architecture")
+}
+func (s *Software)	RemoveVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) error {
+	return fmt.Errorf("unsupported architecture")
+}
+
+func (s *Software)	AddRoute(srcAppGroup uuid.UUID, dstNet net.IPNet, sids []net.IP) error {
+	return fmt.Errorf("unsupported architecture")
+}
+func (s *Software)	RemoveRoute(srcAppGroup uuid.UUID, dstNet string) error {
+	return fmt.Errorf("unsupported architecture")
+}
+
+func NewSoftware(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet, tunRange *net.IPNet) (*Software, error) {
+	return nil, fmt.Errorf("unsupported architecture")
+}

--- a/go-daemon/services/router/dataplane/software_stub.go
+++ b/go-daemon/services/router/dataplane/software_stub.go
@@ -12,41 +12,42 @@ import (
 
 type Software struct {
 }
+
 func (s *Software) Close() error {
 	return fmt.Errorf("unsupported architecture")
 }
 
-func (s *Software)	AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (VNFSubnet, error) {
+func (s *Software) AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (VNFSubnet, error) {
 	return nil, fmt.Errorf("unsupported architecture")
 }
-func (s *Software)	AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error) {
+func (s *Software) AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error) {
 	return nil, fmt.Errorf("unsupported architecture")
 }
 
-func (s *Software)	RemoveApplicationSubnet(appGroupID uuid.UUID) {}
-func (s *Software)	RemoveVNFSubnet(vnfGroupID uuid.UUID) {}
+func (s *Software) RemoveApplicationSubnet(appGroupID uuid.UUID) {}
+func (s *Software) RemoveVNFSubnet(vnfGroupID uuid.UUID)         {}
 
-func (s *Software)	AddApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) (*net.IPNet, string, error) {
+func (s *Software) AddApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) (*net.IPNet, string, error) {
 	return nil, "", fmt.Errorf("unsupported architecture")
 }
-func (s *Software)	RemoveApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) error {
+func (s *Software) RemoveApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) error {
 	return fmt.Errorf("unsupported architecture")
 }
-	
-func (s *Software)	AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) (*net.IPNet, string, error) {
+
+func (s *Software) AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) (*net.IPNet, string, error) {
 	return nil, "", fmt.Errorf("unsupported architecture")
 }
-func (s *Software)	RemoveVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) error {
+func (s *Software) RemoveVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) error {
 	return fmt.Errorf("unsupported architecture")
 }
 
-func (s *Software)	AddRoute(srcAppGroup uuid.UUID, dstNet net.IPNet, sids []net.IP) error {
+func (s *Software) AddRoute(srcAppGroup uuid.UUID, dstNet net.IPNet, sids []net.IP) error {
 	return fmt.Errorf("unsupported architecture")
 }
-func (s *Software)	RemoveRoute(srcAppGroup uuid.UUID, dstNet string) error {
+func (s *Software) RemoveRoute(srcAppGroup uuid.UUID, dstNet string) error {
 	return fmt.Errorf("unsupported architecture")
 }
 
-func NewSoftware(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet, tunRange *net.IPNet) (*Software, error) {
+func NewSoftware(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet, tunRange *net.IPNet) (Manager, error) {
 	return nil, fmt.Errorf("unsupported architecture")
 }

--- a/go-daemon/services/router/dataplane/software_windows.go
+++ b/go-daemon/services/router/dataplane/software_windows.go
@@ -9,41 +9,42 @@ import (
 
 type Software struct {
 }
+
 func (s *Software) Close() error {
 	return fmt.Errorf("Windows is not supported yet")
 }
 
-func (s *Software)	AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (VNFSubnet, error) {
+func (s *Software) AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (VNFSubnet, error) {
 	return nil, fmt.Errorf("Windows is not supported yet")
 }
-func (s *Software)	AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error) {
+func (s *Software) AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error) {
 	return nil, fmt.Errorf("Windows is not supported yet")
 }
 
-func (s *Software)	RemoveApplicationSubnet(appGroupID uuid.UUID) {}
-func (s *Software)	RemoveVNFSubnet(vnfGroupID uuid.UUID) {}
+func (s *Software) RemoveApplicationSubnet(appGroupID uuid.UUID) {}
+func (s *Software) RemoveVNFSubnet(vnfGroupID uuid.UUID)         {}
 
-func (s *Software)	AddApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) (*net.IPNet, string, error) {
+func (s *Software) AddApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) (*net.IPNet, string, error) {
 	return nil, "", fmt.Errorf("Windows is not supported yet")
 }
-func (s *Software)	RemoveApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) error {
+func (s *Software) RemoveApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) error {
 	return fmt.Errorf("Windows is not supported yet")
 }
-	
-func (s *Software)	AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) (*net.IPNet, string, error) {
+
+func (s *Software) AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) (*net.IPNet, string, error) {
 	return nil, "", fmt.Errorf("Windows is not supported yet")
 }
-func (s *Software)	RemoveVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) error {
+func (s *Software) RemoveVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) error {
 	return fmt.Errorf("Windows is not supported yet")
 }
 
-func (s *Software)	AddRoute(srcAppGroup uuid.UUID, dstNet net.IPNet, sids []net.IP) error {
+func (s *Software) AddRoute(srcAppGroup uuid.UUID, dstNet net.IPNet, sids []net.IP) error {
 	return fmt.Errorf("Windows is not supported yet")
 }
-func (s *Software)	RemoveRoute(srcAppGroup uuid.UUID, dstNet string) error {
+func (s *Software) RemoveRoute(srcAppGroup uuid.UUID, dstNet string) error {
 	return fmt.Errorf("Windows is not supported yet")
 }
 
-func NewSoftware(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet, tunRange *net.IPNet) (*Software, error) {
+func NewSoftware(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet, tunRange *net.IPNet) (Manager, error) {
 	return nil, fmt.Errorf("Windows is not supported yet")
 }

--- a/go-daemon/services/router/dataplane/software_windows.go
+++ b/go-daemon/services/router/dataplane/software_windows.go
@@ -1,0 +1,49 @@
+package dataplane
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/google/uuid"
+)
+
+type Software struct {
+}
+func (s *Software) Close() error {
+	return fmt.Errorf("Windows is not supported yet")
+}
+
+func (s *Software)	AddVNFSubnet(vnfGroupID uuid.UUID, sidAmount int) (VNFSubnet, error) {
+	return nil, fmt.Errorf("Windows is not supported yet")
+}
+func (s *Software)	AddApplicationSubnet(appGroupID uuid.UUID) (AppSubnet, error) {
+	return nil, fmt.Errorf("Windows is not supported yet")
+}
+
+func (s *Software)	RemoveApplicationSubnet(appGroupID uuid.UUID) {}
+func (s *Software)	RemoveVNFSubnet(vnfGroupID uuid.UUID) {}
+
+func (s *Software)	AddApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) (*net.IPNet, string, error) {
+	return nil, "", fmt.Errorf("Windows is not supported yet")
+}
+func (s *Software)	RemoveApplicationInstance(appGroupID uuid.UUID, appInstanceID uuid.UUID) error {
+	return fmt.Errorf("Windows is not supported yet")
+}
+	
+func (s *Software)	AddVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) (*net.IPNet, string, error) {
+	return nil, "", fmt.Errorf("Windows is not supported yet")
+}
+func (s *Software)	RemoveVNFInstance(vnfGroupID uuid.UUID, vnfInstanceID uuid.UUID) error {
+	return fmt.Errorf("Windows is not supported yet")
+}
+
+func (s *Software)	AddRoute(srcAppGroup uuid.UUID, dstNet net.IPNet, sids []net.IP) error {
+	return fmt.Errorf("Windows is not supported yet")
+}
+func (s *Software)	RemoveRoute(srcAppGroup uuid.UUID, dstNet string) error {
+	return fmt.Errorf("Windows is not supported yet")
+}
+
+func NewSoftware(sidRange *net.IPNet, appRange *net.IPNet, vnfRange *net.IPNet, tunRange *net.IPNet) (*Software, error) {
+	return nil, fmt.Errorf("Windows is not supported yet")
+}

--- a/go-daemon/services/router/router.go
+++ b/go-daemon/services/router/router.go
@@ -16,16 +16,17 @@ import (
 	"iml-daemon/logger"
 	"iml-daemon/services/events"
 	"iml-daemon/services/routecalc"
+	"iml-daemon/services/router/dataplane"
 	"net"
 )
 
 type RouterService struct {
-	registry  *db.Registry
-	eventBus  *events.EventBus
-	dataplane *Dataplane
+	registry  db.Registry
+	eventBus  events.EventBus
+	dataplane dataplane.Manager
 }
 
-func New(registry *db.Registry, eventBus *events.EventBus, dataplane *Dataplane) (*RouterService, error) {
+func New(registry db.Registry, eventBus events.EventBus, dataplane dataplane.Manager) (*RouterService, error) {
 	// Validate the registry and event bus
 	if registry == nil {
 		return nil, fmt.Errorf("registry cannot be nil")

--- a/go-daemon/services/router/router_test.go
+++ b/go-daemon/services/router/router_test.go
@@ -1,0 +1,39 @@
+package router
+
+import (
+	"iml-daemon/internal/testutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+
+func TestRouterCreationFailsWhenDependenciesAreNil(t *testing.T) {
+	t.Run("Error should be thrown when repo is nil", func(t *testing.T) {
+		t.Parallel()
+		bus := new(testutil.MockEventBus)
+		dataplane := new(testutil.MockDataplaneManager)
+
+		factory, err := New(nil, bus, dataplane)
+		assert.Nil(t, factory)
+		assert.Error(t, err)
+	})
+	t.Run("Error should be thrown when bus is nil", func(t *testing.T) {
+		t.Parallel()
+		repo := new(testutil.MockRepo)
+		dataplane := new(testutil.MockDataplaneManager)
+
+		factory, err := New(repo, nil, dataplane)
+		assert.Nil(t, factory)
+		assert.Error(t, err)
+	})
+	t.Run("Error should be thrown when dataplane is nil", func(t *testing.T) {
+		t.Parallel()
+		repo := new(testutil.MockRepo)
+		bus := new(testutil.MockEventBus)
+
+		factory, err := New(repo, bus, nil)
+		assert.Nil(t, factory)
+		assert.Error(t, err)
+	})
+}

--- a/go-daemon/vnfs/factory.go
+++ b/go-daemon/vnfs/factory.go
@@ -10,7 +10,7 @@ import (
 	"iml-daemon/models"
 	"iml-daemon/services/events"
 	"iml-daemon/services/iml"
-	"iml-daemon/services/router"
+	"iml-daemon/services/router/dataplane"
 	"net"
 	"net/http"
 
@@ -18,10 +18,10 @@ import (
 )
 
 type InstanceFactory struct {
-	repo      *db.Registry
-	bus       *events.EventBus
-	dataplane *router.Dataplane
-	imlClient *iml.Client
+	repo      db.Registry
+	bus       events.EventBus
+	dataplane dataplane.Manager
+	imlClient iml.Client
 }
 
 type RegistrationRequest struct {
@@ -38,7 +38,7 @@ type InstanceRegistrationResponse struct {
 	BridgeName  string
 }
 
-func NewInstanceFactory(repo *db.Registry, bus *events.EventBus, dataplane *router.Dataplane, imlClient *iml.Client) (*InstanceFactory, error) {
+func NewInstanceFactory(repo db.Registry, bus events.EventBus, dataplane dataplane.Manager, imlClient iml.Client) (*InstanceFactory, error) {
 	if bus == nil {
 		return nil, fmt.Errorf("event bus is required")
 	}
@@ -114,11 +114,11 @@ func (f *InstanceFactory) newLocalSimpleInstance(nfUID string, vnf *models.Virtu
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to request subnet for VNF %s: %v", nfUID, err)
 		}
-		sid := subnet.SIDs[0]
+		sid := subnet.SIDs()[0]
 		vnfGroup.SID = sid.String()
-		vnfGroup.Subnet = subnet.Network.String()
-		vnfGroup.GatewayIP = subnet.GatewayIP.String()
-		vnfGroup.Bridge = subnet.Bridge.Attrs().Name
+		vnfGroup.Subnet = subnet.Network().String()
+		vnfGroup.GatewayIP = subnet.GatewayIP().String()
+		vnfGroup.Bridge = subnet.Bridge()
 		if err := f.repo.SaveVnfGroup(vnfGroup); err != nil {
 			return nil, nil, fmt.Errorf("failed to update VNF group %s with sid %s: %v", vnfGroup.ID, vnfGroup.SID, err)
 		}
@@ -175,12 +175,12 @@ func (f *InstanceFactory) newLocalMultiplexedInstance(nfUID string, vnf *models.
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to request subnet for VNF %s: %v", nfUID, err)
 		}
-		vnfGroup.Subnet = subnet.Network.String()
-		vnfGroup.GatewayIP = subnet.GatewayIP.String()
-		vnfGroup.Bridge = subnet.Bridge.Attrs().Name
+		vnfGroup.Subnet = subnet.Network().String()
+		vnfGroup.GatewayIP = subnet.GatewayIP().String()
+		vnfGroup.Bridge = subnet.Bridge()
 
 		sidAssignments := []models.SidAssignment{}
-		for i, sid := range subnet.SIDs {
+		for i, sid := range subnet.SIDs() {
 			sidAssignments = append(sidAssignments, models.SidAssignment{
 				VNFSubfunctionID:      vnf.Subfunctions[i].SubfunctionID,
 				SID:                   sid.String(),
@@ -307,8 +307,8 @@ func (f *InstanceFactory) deleteMultiplexedInstance(instance *models.Multiplexed
 
 func (f *InstanceFactory) publishAssignmentsToP4Controller(vnfID string, groupID uuid.UUID, sidAssignments []models.SidAssignment) error {
 	type AssignmentPayload struct {
-		SubfunctionID uint32   `json:"subfunction_id"`
-		SID           string   `json:"sid"`
+		SubfunctionID uint32 `json:"subfunction_id"`
+		SID           string `json:"sid"`
 	}
 
 	var payloads []AssignmentPayload
@@ -338,4 +338,3 @@ func (f *InstanceFactory) publishAssignmentsToP4Controller(vnfID string, groupID
 
 	return nil
 }
-

--- a/go-daemon/vnfs/factory.go
+++ b/go-daemon/vnfs/factory.go
@@ -17,28 +17,14 @@ import (
 	"github.com/google/uuid"
 )
 
-type InstanceFactory struct {
+type InstanceFactoryImpl struct {
 	repo      db.Registry
 	bus       events.EventBus
 	dataplane dataplane.Manager
 	imlClient iml.Client
 }
 
-type RegistrationRequest struct {
-	VnfID       string
-	ContainerID string
-}
-
-type InstanceRegistrationResponse struct {
-	IPNet       net.IPNet
-	SIDs        []net.IPNet
-	IfaceName   string
-	ClusterCIDR net.IPNet
-	GatewayIP   net.IP
-	BridgeName  string
-}
-
-func NewInstanceFactory(repo db.Registry, bus events.EventBus, dataplane dataplane.Manager, imlClient iml.Client) (*InstanceFactory, error) {
+func NewInstanceFactory(repo db.Registry, bus events.EventBus, dataplane dataplane.Manager, imlClient iml.Client) (InstanceFactory, error) {
 	if bus == nil {
 		return nil, fmt.Errorf("event bus is required")
 	}
@@ -52,7 +38,7 @@ func NewInstanceFactory(repo db.Registry, bus events.EventBus, dataplane datapla
 		return nil, fmt.Errorf("IML client is required")
 	}
 
-	return &InstanceFactory{
+	return &InstanceFactoryImpl{
 		repo:      repo,
 		bus:       bus,
 		dataplane: dataplane,
@@ -60,7 +46,7 @@ func NewInstanceFactory(repo db.Registry, bus events.EventBus, dataplane datapla
 	}, nil
 }
 
-func (f *InstanceFactory) NewLocalInstance(req *RegistrationRequest) (*InstanceRegistrationResponse, error) {
+func (f *InstanceFactoryImpl) NewLocalInstance(req *RegistrationRequest) (*InstanceRegistrationResponse, error) {
 	vnf, err := f.imlClient.GetNetworkFunction(req.VnfID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get VNF %s: %v", req.VnfID, err)
@@ -99,7 +85,7 @@ func (f *InstanceFactory) NewLocalInstance(req *RegistrationRequest) (*InstanceR
 	}
 }
 
-func (f *InstanceFactory) newLocalSimpleInstance(nfUID string, vnf *models.VirtualNetworkFunction, containerID string) (*models.SimpleVnfInstance, *models.SimpleVnfGroup, error) {
+func (f *InstanceFactoryImpl) newLocalSimpleInstance(nfUID string, vnf *models.VirtualNetworkFunction, containerID string) (*models.SimpleVnfInstance, *models.SimpleVnfGroup, error) {
 	vnfGroup, _ := f.repo.FindLocalSimpleVnfGroupByVnfID(nfUID)
 	if vnfGroup == nil {
 		vnfGroup = &models.SimpleVnfGroup{
@@ -160,7 +146,7 @@ func (f *InstanceFactory) newLocalSimpleInstance(nfUID string, vnf *models.Virtu
 	return instance, vnfGroup, nil
 }
 
-func (f *InstanceFactory) newLocalMultiplexedInstance(nfUID string, vnf *models.VirtualNetworkFunction, containerID string) (*models.MultiplexedVnfInstance, *models.MultiplexedVnfGroup, error) {
+func (f *InstanceFactoryImpl) newLocalMultiplexedInstance(nfUID string, vnf *models.VirtualNetworkFunction, containerID string) (*models.MultiplexedVnfInstance, *models.MultiplexedVnfGroup, error) {
 	vnfGroup, _ := f.repo.FindLocalMultiplexedGroupByVnfID(nfUID)
 	if vnfGroup == nil {
 		vnfGroup = &models.MultiplexedVnfGroup{
@@ -234,7 +220,7 @@ func (f *InstanceFactory) newLocalMultiplexedInstance(nfUID string, vnf *models.
 	return instance, vnfGroup, nil
 }
 
-func (f *InstanceFactory) TeardownVnfInstance(containerID string) error {
+func (f *InstanceFactoryImpl) TeardownVnfInstance(containerID string) error {
 	instance, err := f.repo.FindVnfInstanceByContainerID(containerID)
 	if err == nil && instance != nil {
 		return f.deleteSimpleInstance(instance)
@@ -248,7 +234,7 @@ func (f *InstanceFactory) TeardownVnfInstance(containerID string) error {
 	return nil
 }
 
-func (f *InstanceFactory) deleteSimpleInstance(instance *models.SimpleVnfInstance) error {
+func (f *InstanceFactoryImpl) deleteSimpleInstance(instance *models.SimpleVnfInstance) error {
 	// Remove the instance from the dataplane
 	if err := f.dataplane.RemoveVNFInstance(instance.GroupID, instance.ID); err != nil {
 		return fmt.Errorf("failed to remove VNF instance from dataplane: %v", err)
@@ -278,7 +264,7 @@ func (f *InstanceFactory) deleteSimpleInstance(instance *models.SimpleVnfInstanc
 	return nil
 }
 
-func (f *InstanceFactory) deleteMultiplexedInstance(instance *models.MultiplexedVnfInstance) error {
+func (f *InstanceFactoryImpl) deleteMultiplexedInstance(instance *models.MultiplexedVnfInstance) error {
 	// Remove the instance from the dataplane
 	if err := f.dataplane.RemoveVNFInstance(instance.GroupID, instance.ID); err != nil {
 		return fmt.Errorf("failed to remove VNF instance from dataplane: %v", err)
@@ -308,7 +294,7 @@ func (f *InstanceFactory) deleteMultiplexedInstance(instance *models.Multiplexed
 	return nil
 }
 
-func (f *InstanceFactory) publishAssignmentsToP4Controller(vnfID string, groupID uuid.UUID, sidAssignments []models.SidAssignment) error {
+func (f *InstanceFactoryImpl) publishAssignmentsToP4Controller(vnfID string, groupID uuid.UUID, sidAssignments []models.SidAssignment) error {
 	type AssignmentPayload struct {
 		SubfunctionID uint32 `json:"subfunction_id"`
 		SID           string `json:"sid"`

--- a/go-daemon/vnfs/factory.go
+++ b/go-daemon/vnfs/factory.go
@@ -48,6 +48,9 @@ func NewInstanceFactory(repo db.Registry, bus events.EventBus, dataplane datapla
 	if dataplane == nil {
 		return nil, fmt.Errorf("dataplane is required")
 	}
+	if imlClient == nil {
+		return nil, fmt.Errorf("IML client is required")
+	}
 
 	return &InstanceFactory{
 		repo:      repo,

--- a/go-daemon/vnfs/types.go
+++ b/go-daemon/vnfs/types.go
@@ -1,0 +1,22 @@
+package vnfs
+
+import "net"
+
+type InstanceFactory interface {
+	NewLocalInstance(req *RegistrationRequest) (*InstanceRegistrationResponse, error)
+	TeardownVnfInstance(containerID string) error
+}
+
+type RegistrationRequest struct {
+	VnfID       string
+	ContainerID string
+}
+
+type InstanceRegistrationResponse struct {
+	IPNet       net.IPNet
+	SIDs        []net.IPNet
+	IfaceName   string
+	ClusterCIDR net.IPNet
+	GatewayIP   net.IP
+	BridgeName  string
+}

--- a/go-daemon/vnfs/vnfs_test.go
+++ b/go-daemon/vnfs/vnfs_test.go
@@ -1,0 +1,51 @@
+package vnfs
+
+import (
+	"testing"
+	"iml-daemon/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDummy(t *testing.T) {
+	// Defining the columns of the table
+	var tests = []struct {
+		name string
+			input *RegistrationRequest
+			want  *InstanceRegistrationResponse
+	}{
+		// the table itself
+		{"9 should be Foo", 
+			&RegistrationRequest{}, 
+			&InstanceRegistrationResponse{}},
+		{"3 should be Foo", 
+			&RegistrationRequest{}, 
+			&InstanceRegistrationResponse{}},
+		{"1 is not Foo", 
+			&RegistrationRequest{}, 
+			&InstanceRegistrationResponse{}},
+		{"0 should be Foo", 
+			&RegistrationRequest{}, 
+			&InstanceRegistrationResponse{}},
+	}
+
+	// Create the mock dependencies
+	repo := new(testutil.MockRepo)
+	bus := new(testutil.MockEventBus)
+	dataplane := new(testutil.MockDataplaneManager)
+	imlClient := new(testutil.MockIMLClient)
+
+	// Set up the factory
+	factory, err := NewInstanceFactory(repo, bus, dataplane, imlClient)
+	assert.NoError(t, err)
+
+	// The execution loop
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel() // Run test in parallel
+			response, err := factory.NewLocalInstance(tt.input)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, response)
+		})
+	}
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,5 @@
 kubectl delete -f runtime-proxy/install.yml
+kubectl delete -f iml-oakestra-agent/install.yml
 kubectl delete -f go-daemon/install.yml
 kubectl delete -f cni/install.yml
 kubectl delete -f builder/dist/install.yaml
-kubectl delete -f iml-oakestra-agent/install.yml


### PR DESCRIPTION
Refactored each service to use interfaces instead of pointers to structs. This helps with adding different implementations for behaviors and also to allow service Mocking, which is essential for testing